### PR TITLE
Add RLBot configs for Destroyer bot

### DIFF
--- a/destroyer.cfg
+++ b/destroyer.cfg
@@ -1,0 +1,15 @@
+[Locations]
+# Paths are RELATIVE to this cfg file
+python_file = bot.py
+looks_config = appearance.cfg
+requirements_file = requirements.txt
+name = Destroyer
+use_virtual_environment = False
+supports_early_start = True
+
+[Details]
+developer = ZeroII99II
+description = Destroyer — SSL-focused bot with aerial curriculum, speed-flip kickoff, and hot-reload.
+language = Python
+tags = 1v1, training, ml
+

--- a/rlbot.cfg
+++ b/rlbot.cfg
@@ -1,0 +1,24 @@
+[RLBot Configuration]
+launcher_preference = steam
+
+[Match Configuration]
+num_participants = 2
+game_mode = Soccar
+game_map = Mannfield
+skip_replays = True
+enable_state_setting = True
+
+[Mutator Configuration]
+Game Speed = Default
+Match Length = 5 Minutes
+Boost Amount = Default
+
+[Participant Configuration]
+participant_config_0 = destroyer.cfg
+participant_team_0 = 0
+participant_type_0 = rlbot
+
+participant_config_1 = destroyer.cfg
+participant_team_1 = 1
+participant_type_1 = rlbot
+


### PR DESCRIPTION
## Summary
- Add per-bot config `destroyer.cfg` for the Destroyer agent
- Add match config `rlbot.cfg` to run Destroyer in RLBot GUI

## Testing
- `python -m py_compile bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68b7d400766c83238eadeb0b6e9f795e