### PR TITLE
Resume training from Necto with hot reload and kickoff fixes

### DIFF
--- a/destroyer.cfg
+++ b/destroyer.cfg
@@ -1,5 +1,4 @@
 [Locations]
-# Paths are RELATIVE to this cfg file
 python_file = bot.py
 looks_config = appearance.cfg
 requirements_file = requirements.txt
@@ -9,7 +8,6 @@ supports_early_start = True
 
 [Details]
 developer = ZeroII99II
-description = Destroyer — SSL-focused bot with aerial curriculum, speed-flip kickoff, and hot-reload.
+description = Destroyer — resumes from Necto, hot-reload, speed-flip KO, SSL curriculum.
 language = Python
 tags = 1v1, training, ml
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,4 @@
-# Include everything the framework requires
-rlbot>=1.74.0
---find-links https://download.pytorch.org/whl/torch_stable.html
-torch>=2.1
-rlgym-compat==1.0.2
-numpy>=1.24
+rlbot==1.68.0
+numpy>=1.24,<2.0
 gymnasium>=0.29
-
-# This will cause pip to auto-upgrade and stop scaring people with warning messages
-pip
+torch>=2.1

--- a/trainer_online_bc.py
+++ b/trainer_online_bc.py
@@ -6,7 +6,7 @@ except Exception:
     TORCH_OK = False
 
 class OnlineBC:
-    def __init__(self, buffer, policy, out_path="necto-model.pt", step_every=3.0, batch=256, lr=2e-4):
+    def __init__(self, buffer, policy, out_path="destroyer.pt", step_every=3.0, batch=256, lr=2e-4):
         self.buffer = buffer
         self.policy = policy
         self.out_path = out_path
@@ -52,10 +52,13 @@ class OnlineBC:
             except Exception:
                 continue
 
+            # Save to the exact file the policy is currently using
+            save_target = getattr(self.policy, "path", self.out_path)
             if time.time() - last_save > self.step_every:
                 try:
-                    torch.jit.save(model, self.out_path)
+                    torch.jit.save(model, save_target)
                     last_save = time.time()
+                    print(f"[trainer] saved -> {save_target}")
                 except Exception:
                     pass
 


### PR DESCRIPTION
## Summary
- Pin requirements for RLBot 1.68.0 and constrain numpy <2
- Load TorchScript models with fallbacks and hot-reload support
- Resume from Necto model, add fallback controls, and ensure post-pause kickoffs

## Testing
- `python -m py_compile live_policy.py trainer_online_bc.py bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68b7d9ee2b5c8323bda92271d1587786