### PR TITLE
Add heuristic fallback and adaptive kickoff strategies

### DIFF
--- a/kickoff_strats.py
+++ b/kickoff_strats.py
@@ -1,0 +1,214 @@
+# kickoff_strats.py — Pro kickoff strategies + adaptive director for 1v1
+from dataclasses import dataclass, field
+from enum import Enum
+import math, random
+import numpy as np
+from rlbot.agents.base_agent import SimpleControllerState
+from kickoff_detector import Spawn
+
+# ------------ helpers ------------
+def _clip(x, lo=-1.0, hi=1.0): return float(max(lo, min(hi, x)))
+def _hyp(x, y): return math.hypot(x, y)
+
+def _ang_norm(a):
+    while a > math.pi: a -= 2*math.pi
+    while a < -math.pi: a += 2*math.pi
+    return a
+
+def _vec2(x, y):
+    return np.array([float(x), float(y)], dtype=np.float32)
+
+def _yaw(rot): return float(rot.yaw)
+def _forward2(rot):
+    cy, sy = math.cos(rot.yaw), math.sin(rot.yaw)
+    cp = math.cos(rot.pitch)
+    return np.array([cp * cy, cp * sy], dtype=np.float32)
+
+def _sign_to_opp(team):  # +Y towards orange goal if we're blue (team 0)
+    return -1.0 if team == 0 else 1.0
+
+# Corner boost approximate world coords
+CORNER_BOOSTS = [
+    np.array([-3072.0, -4096.0], dtype=np.float32),
+    np.array([ 3072.0, -4096.0], dtype=np.float32),
+    np.array([-3072.0,  4096.0], dtype=np.float32),
+    np.array([ 3072.0,  4096.0], dtype=np.float32),
+]
+
+# ------------- core timings -------------
+@dataclass
+class SpeedFlipParams:
+    jump1_time: float = 0.06
+    jump2_delay: float = 0.17
+    bail_frontflip: bool = True
+
+# ------------- primitive steering -------------
+def steer_towards(current_yaw: float, target: np.ndarray, my_pos: np.ndarray, yaw_rate: float = 0.0):
+    kp, kd = 2.2, 0.7
+    tgt_yaw = math.atan2(target[1] - my_pos[1], target[0] - my_pos[0])
+    ang = _ang_norm(tgt_yaw - current_yaw)
+    steer = _clip(kp * ang - kd * yaw_rate)
+    return steer, abs(ang)
+
+# ------------- wave dash helper -------------
+def maybe_wave_dash(ctl: SimpleControllerState, t_since: float, land_pitch: float = -0.2):
+    # tiny landing accel if in the right time window
+    if 0.65 < t_since < 0.85:
+        ctl.jump = True
+        ctl.pitch = 1.0
+        ctl.boost = True
+    elif t_since >= 0.85:
+        ctl.pitch = land_pitch
+    return ctl
+
+# ------------- strategies -------------
+def strat_speedflip(packet, my_car, spawn: Spawn, ctl: SimpleControllerState, t_since: float, P: SpeedFlipParams):
+    ctl.throttle = 1.0; ctl.boost = True
+    if spawn in (Spawn.DIAG_L, Spawn.DIAG_R):
+        sign = -1.0 if spawn == Spawn.DIAG_L else +1.0
+        ctl.steer = sign * 0.55
+        ctl.yaw = sign * 0.25
+    # jump timings
+    if P.jump1_time <= t_since < P.jump1_time + 0.05:
+        ctl.jump = True; ctl.pitch = 1.0
+    if (P.jump1_time + P.jump2_delay) <= t_since < (P.jump1_time + P.jump2_delay + 0.05):
+        ctl.jump = True
+        if spawn in (Spawn.DIAG_L, Spawn.DIAG_R):
+            ctl.yaw = (-1.0 if spawn == Spawn.DIAG_L else 1.0)
+        ctl.pitch = 1.0
+    if t_since >= P.jump1_time + P.jump2_delay + 0.18:
+        ctl.yaw = 0.0; ctl.pitch = -0.2
+    if P.bail_frontflip and t_since > 0.7:
+        ctl.jump = True; ctl.pitch = 1.0; ctl.boost = True
+    return maybe_wave_dash(ctl, t_since)
+
+def strat_delayed_speedflip(packet, my_car, spawn: Spawn, ctl: SimpleControllerState, t_since: float, delay: float, P: SpeedFlipParams):
+    if t_since < delay:
+        # hold a beat to mess up mirror speedflips
+        ctl.throttle = 0.0; ctl.boost = False; ctl.steer = 0.0
+        return ctl
+    return strat_speedflip(packet, my_car, spawn, ctl, t_since - delay, P)
+
+def strat_hook(packet, my_car, spawn: Spawn, ctl: SimpleControllerState, t_since: float, hook_dir: int, P: SpeedFlipParams):
+    """
+    Hook left/right: curve path to hit ball off-center for a favorable pinch.
+    hook_dir = -1 (left) or +1 (right) relative to our POV.
+    """
+    ctl = strat_speedflip(packet, my_car, spawn, ctl, t_since, P)
+    # extra steer bias early
+    if t_since < 0.5:
+        ctl.steer = _clip(ctl.steer + 0.35 * hook_dir)
+        ctl.yaw = _clip((ctl.yaw or 0.0) + 0.15 * hook_dir)
+    return ctl
+
+def strat_fake(packet, my_car, ctl: SimpleControllerState, t_since: float):
+    """
+    Fake: wait ~0.65s, turn to nearest corner boost, secure possession.
+    """
+    me = my_car
+    my_pos = _vec2(me.physics.location.x, me.physics.location.y)
+    # wait first; show fake
+    if t_since < 0.65:
+        ctl.throttle = 0.0; ctl.boost = False; ctl.steer = 0.0
+        return ctl
+    # pick nearest corner in our half
+    team = me.team
+    half_sign = -1.0 if team == 0 else 1.0
+    candidates = [b for b in CORNER_BOOSTS if math.copysign(1.0, b[1]) == half_sign]
+    target = min(candidates, key=lambda b: float(np.linalg.norm(b - my_pos)))
+    yaw = _yaw(me.physics.rotation)
+    yaw_rate = float(getattr(me.physics.angular_velocity, "z", 0.0))
+    steer, ang_abs = steer_towards(yaw, target, my_pos, yaw_rate)
+    ctl.steer = steer
+    ctl.handbrake = 1.0 if (ang_abs > 1.3) else 0.0
+    ctl.boost = 1.0 if ang_abs < 0.25 else 0.0
+    ctl.throttle = 1.0
+    return ctl
+
+# ------------- Adaptive director -------------
+@dataclass
+class StrategyWeights:
+    speedflip: float = 0.60
+    delayed: float = 0.15
+    hook_left: float = 0.10
+    hook_right: float = 0.10
+    fake: float = 0.05
+
+@dataclass
+class KickoffBook:
+    rng_seed: int = 0
+    weights_mid: StrategyWeights = field(default_factory=StrategyWeights)
+    weights_diag: StrategyWeights = field(default_factory=StrategyWeights)
+    weights_back: StrategyWeights = field(default_factory=StrategyWeights)
+    last_outcomes: list = field(default_factory=list)  # list of (+1 scored/-1 conceded/0 neutral)
+    delay_window: tuple = (0.06, 0.12)  # delayed sf window
+
+    def __post_init__(self):
+        random.seed(self.rng_seed)
+
+    def _pick(self, spawn: Spawn) -> str:
+        w = self.weights_diag if spawn in (Spawn.DIAG_L, Spawn.DIAG_R) else (self.weights_mid if spawn == Spawn.MID else self.weights_back)
+        table = [("speedflip", w.speedflip),
+                 ("delayed",   w.delayed),
+                 ("hook_left", w.hook_left),
+                 ("hook_right",w.hook_right),
+                 ("fake",      w.fake)]
+        tot = sum(v for _, v in table) or 1.0
+        r = random.random() * tot
+        acc = 0.0
+        for name, v in table:
+            acc += v
+            if r <= acc: return name
+        return "speedflip"
+
+    def _nudge(self, spawn: Spawn, good: bool, name: str):
+        # tiny bandit-style nudge to favor what worked
+        scale = 0.03 if good else -0.03
+        w = self.weights_diag if spawn in (Spawn.DIAG_L, Spawn.DIAG_R) else (self.weights_mid if spawn == Spawn.MID else self.weights_back)
+        cur = getattr(w, name if name in ("fake", "delayed", "speedflip") else ("hook_left" if name=="hook_left" else "hook_right"), None)
+        if cur is None: return
+        newv = max(0.02, min(0.85, cur + scale))
+        setattr(w, name if name in ("fake", "delayed", "speedflip") else ("hook_left" if name=="hook_left" else "hook_right"), newv)
+        # normalize a bit
+        s = w.speedflip + w.delayed + w.hook_left + w.hook_right + w.fake
+        w.speedflip /= s; w.delayed /= s; w.hook_left /= s; w.hook_right /= s; w.fake /= s
+
+class KickoffDirector:
+    def __init__(self, seed=0):
+        self.book = KickoffBook(rng_seed=seed)
+        self.active_name = None
+        self.delay_chosen = 0.08
+        self.P = SpeedFlipParams()
+        self.spawn = Spawn.MID
+
+    def start(self, spawn: Spawn):
+        self.spawn = spawn
+        self.active_name = self.book._pick(spawn)
+        if self.active_name == "delayed":
+            lo, hi = self.book.delay_window
+            self.delay_chosen = random.uniform(lo, hi)
+
+    def run(self, packet, my_car, t_since: float, ctl: SimpleControllerState):
+        # dispatch
+        if self.active_name == "speedflip":
+            return strat_speedflip(packet, my_car, self.spawn, ctl, t_since, self.P)
+        if self.active_name == "delayed":
+            return strat_delayed_speedflip(packet, my_car, self.spawn, ctl, t_since, self.delay_chosen, self.P)
+        if self.active_name == "hook_left":
+            return strat_hook(packet, my_car, self.spawn, ctl, t_since, hook_dir=-1, P=self.P)
+        if self.active_name == "hook_right":
+            return strat_hook(packet, my_car, self.spawn, ctl, t_since, hook_dir=+1, P=self.P)
+        if self.active_name == "fake":
+            return strat_fake(packet, my_car, ctl, t_since)
+        # default
+        return strat_speedflip(packet, my_car, self.spawn, ctl, t_since, self.P)
+
+    def report_outcome(self, spawn: Spawn, scored: bool, conceded: bool):
+        name = self.active_name or "speedflip"
+        # Update weights based on outcome
+        if scored and not conceded:
+            self.book._nudge(spawn, True, name)
+        elif conceded and not scored:
+            self.book._nudge(spawn, False, name)
+        # else neutral: no change
+        self.active_name = None

--- a/simple_policy.py
+++ b/simple_policy.py
@@ -1,0 +1,110 @@
+# simple_policy.py — baseline 1v1 controller: intercept ball + aim through it toward opponent goal.
+import numpy as np, math
+from rlbot.agents.base_agent import SimpleControllerState
+
+def _ang_norm(a):
+    # normalize to [-pi, pi]
+    while a > math.pi: a -= 2*math.pi
+    while a < -math.pi: a += 2*math.pi
+    return a
+
+def _vec(x, y): return np.array([float(x), float(y)], dtype=np.float32)
+
+
+def _yaw(rot): return float(rot.yaw)
+
+def _forward(rot):
+    # 2D forward on XY plane
+    cy, sy = math.cos(rot.yaw), math.sin(rot.yaw)
+    cp = math.cos(rot.pitch)
+    return np.array([cp * cy, cp * sy], dtype=np.float32)
+
+def _speed_xy(v): return float(np.hypot(v.x, v.y))
+
+def _sign_to_opp(team):  # +Y towards orange goal, -Y towards blue goal
+    return -1.0 if team == 0 else 1.0
+
+def _aim_point(ball_loc, ball_vel, team, approach_dist=120.0):
+    # Place a point *behind* the ball along the line to opponent goal so we hit it toward their net.
+    goal = np.array([0.0, 5120.0 * _sign_to_opp(1-team)], dtype=np.float32)  # opponent goal center
+    b = _vec(ball_loc.x, ball_loc.y)
+    dir_to_goal = goal - b
+    n = np.linalg.norm(dir_to_goal) + 1e-6
+    back = b - dir_to_goal / n * approach_dist
+    return back
+
+def _predict_ball(ball_loc, ball_vel, t):
+    return _vec(ball_loc.x + ball_vel.x * t, ball_loc.y + ball_vel.y * t)
+
+class HeuristicBrain:
+    """
+    Produces an 8-dim action vector [steer, throttle, pitch, yaw, roll, jump, boost, handbrake]
+    which gets converted to SimpleControllerState by your to_controller().
+    """
+    def __init__(self):
+        # Tunables
+        self.kp = 2.2            # steering P gain
+        self.kd = 0.7            # steering D gain on yaw rate
+        self.handbrake_thresh = 1.2  # rad; use powerslide when angle is large & close
+        self.align_boost_thresh = 0.30 # rad; boost when well aligned
+        self.flip_jump_speed = 1800.0  # consider a forward flip when slow & far
+        self.flip_dist = 2200.0
+
+    def action(self, packet, index) -> np.ndarray:
+        me = packet.game_cars[index]
+        ball = packet.game_ball
+        team = me.team
+
+        my_pos = _vec(me.physics.location.x, me.physics.location.y)
+        my_yaw = _yaw(me.physics.rotation)
+        my_fwd = _forward(me.physics.rotation)
+        my_vel = _vec(me.physics.velocity.x, me.physics.velocity.y)
+        my_speed = float(np.linalg.norm(my_vel))
+        yaw_rate = float(getattr(me.physics.angular_velocity, "z", 0.0))
+
+        # Simple time-to-intercept guess and aim
+        dist = float(np.linalg.norm(_vec(ball.physics.location.x, ball.physics.location.y) - my_pos))
+        # Choose a lookahead proportional to distance but capped to keep it sane
+        t_look = max(0.05, min(1.2, dist / max(1200.0, my_speed + 400.0)))
+        target_ball = _predict_ball(ball.physics.location, ball.physics.velocity, t_look)
+        aim = _aim_point(ball.physics.location, ball.physics.velocity, team, approach_dist=140.0)
+
+        # Blend: mostly aim-behind-ball, but slightly toward predicted position for dynamic approach
+        target = 0.75 * aim + 0.25 * target_ball
+
+        to_target = target - my_pos
+        target_yaw = math.atan2(to_target[1], to_target[0])
+        ang_err = _ang_norm(target_yaw - my_yaw)  # desired steering angle
+        steer = np.clip(self.kp * ang_err - self.kd * yaw_rate, -1.0, 1.0)
+
+        # Throttle logic
+        throttle = 1.0
+        reverse = False
+        if abs(ang_err) > 2.35:  # ~135 deg wrong way; back up instead of endless circles
+            reverse = True
+        if reverse:
+            throttle = -0.5
+        # Handbrake for tight turns when close AND big angle
+        handbrake = 1.0 if (abs(ang_err) > self.handbrake_thresh and dist < 1500.0) else 0.0
+
+        # Boost when aligned and not already fast
+        boost = 1.0 if (abs(ang_err) < self.align_boost_thresh and my_speed < 2200.0) else 0.0
+
+        # Simple jump / double jump for high balls in front
+        jump = 0.0
+        if ball.physics.location.z > 420 and abs(ang_err) < 0.35 and dist < 1000.0:
+            jump = 1.0
+
+        # Opportunistic forward flip when far and slow but aligned
+        if dist > self.flip_dist and my_speed < self.flip_jump_speed and abs(ang_err) < 0.20:
+            jump = 1.0  # one-tap; your speedflip code will handle KO; this is mid-field burst
+
+        # Map to 8-dim action
+        a = np.array([
+            float(steer), float(throttle),
+            0.0, 0.0, 0.0,               # pitch,yaw,roll (not used by ground controller)
+            float(jump),
+            float(boost),
+            float(handbrake)
+        ], dtype=np.float32)
+        return a


### PR DESCRIPTION
## Summary
- Enable online trainer and add heuristic baseline policy for ball-chasing when model actions are weak
- Introduce adaptive kickoff director with multiple strategies and outcome-based weighting
- Replace simple kickoff and fallback logic to leverage heuristic brain and kickoff director

## Testing
- `python -m py_compile bot.py simple_policy.py kickoff_strats.py trainer_online_bc.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b7ea0c18408323aec45859b1ed25cd