### PR TITLE
Ensure normal match speed and add autosave checkpoints

### DIFF
--- a/autosave.py
+++ b/autosave.py
@@ -1,0 +1,78 @@
+# autosave.py — periodic model saver + checkpoint rotation
+import os, time, datetime, threading, shutil
+from pathlib import Path
+
+try:
+    import torch
+    TORCH_OK = True
+except Exception:
+    TORCH_OK = False
+
+class ModelAutoSaver:
+    def __init__(self, policy, interval_sec=300, checkpoint_dir="checkpoints", max_keep=12):
+        """
+        policy: LivePolicy instance with .model (TorchScript) and .path (str)
+        interval_sec: how often to save (default 5 minutes)
+        checkpoint_dir: folder for timestamped backups
+        max_keep: how many timestamped backups to keep
+        """
+        self.policy = policy
+        self.interval = max(60, int(interval_sec))
+        self.ckpt_dir = Path(checkpoint_dir)
+        self.max_keep = max_keep
+        self.stop_flag = False
+        self._thread = None
+
+    def start(self):
+        if not TORCH_OK:
+            return
+        self.ckpt_dir.mkdir(parents=True, exist_ok=True)
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+
+    def stop(self):
+        self.stop_flag = True
+
+    def _rotate(self):
+        files = sorted(self.ckpt_dir.glob("*.pt"), key=lambda p: p.stat().st_mtime)
+        while len(files) > self.max_keep:
+            try:
+                files[0].unlink(missing_ok=True)
+            except Exception:
+                pass
+            files = files[1:]
+
+    def _run(self):
+        last_saved_to = None
+        while not self.stop_flag:
+            time.sleep(self.interval)
+            try:
+                model = getattr(self.policy, "model", None)
+                target = getattr(self.policy, "path", None)
+                if not (TORCH_OK and model is not None and target):
+                    continue
+
+                # 1) Save/refresh the live working model
+                try:
+                    torch.jit.save(model, target)
+                    print(f"[autosave] saved live model -> {target}")
+                    last_saved_to = target
+                except Exception as e:
+                    print(f"[autosave] live save failed: {e}")
+
+                # 2) Also write a timestamped checkpoint
+                ts = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
+                ck = self.ckpt_dir / f"destroyer_{ts}.pt"
+                try:
+                    # Reuse the just-written file for speed (copy) if possible
+                    if last_saved_to and Path(last_saved_to).exists():
+                        shutil.copy(last_saved_to, ck)
+                    else:
+                        torch.jit.save(model, ck)
+                    print(f"[autosave] checkpoint -> {ck}")
+                except Exception as e:
+                    print(f"[autosave] checkpoint failed: {e}")
+
+                self._rotate()
+            except Exception:
+                pass

--- a/rlbot.cfg
+++ b/rlbot.cfg
@@ -10,7 +10,7 @@ enable_state_setting = True
 
 [Mutator Configuration]
 Game Speed = Default
-Match Length = 5 Minutes
+Match Length = Unlimited
 Boost Amount = Default
 
 [Participant Configuration]

--- a/trainer_online_bc.py
+++ b/trainer_online_bc.py
@@ -5,6 +5,8 @@ try:
 except Exception:
     TORCH_OK = False
 
+SAVE_INTERVAL_S = 60.0  # write trained weights to disk at most once per minute
+
 class OnlineBC:
     def __init__(self, buffer, policy, out_path="destroyer.pt", step_every=3.0, batch=256, lr=2e-4):
         self.buffer = buffer
@@ -54,7 +56,7 @@ class OnlineBC:
 
             # Save to the exact file the policy is currently using (working copy)
             save_target = getattr(self.policy, "path", self.out_path)
-            if time.time() - last_save > self.step_every:
+            if time.time() - last_save > SAVE_INTERVAL_S:
                 try:
                     torch.jit.save(model, save_target)
                     last_save = time.time()


### PR DESCRIPTION
## Summary
- enforce default speed and unlimited match length via rlbot.cfg
- add periodic autosaver with rotating checkpoints and integrate into bot
- warn if game time slows down and throttle trainer save frequency

## Testing
- `python -m py_compile autosave.py bot.py trainer_online_bc.py && echo "py_compile success"`


------
https://chatgpt.com/codex/tasks/task_e_68b7ecd70a808323aedf02f1a3e696ab