### PR TITLE
Add SSL mechanics telemetry and curriculum drills

### DIFF
--- a/drills_ssl.py
+++ b/drills_ssl.py
@@ -1,0 +1,178 @@
+# drills_ssl.py — curriculum state injectors for SSL mechanics
+import numpy as np
+from rlbot.utils.game_state_util import GameState, BallState, CarState, Physics, Vector3, Rotator
+from mechanics_ssl import _vec2
+
+
+def _rand(a, b):
+    return float(a + np.random.rand() * (b - a))
+
+
+def inject_fast_aerial(agent):
+    # place ball high center, car somewhat back
+    team = agent.team
+    car_x = _rand(-1500, 1500)
+    car_y = _rand(-2500, -1500) if team == 0 else _rand(1500, 2500)
+    if team == 1:
+        car_y *= -1
+    car_z = _rand(50, 120)
+    ball_x = _rand(-600, 600)
+    ball_y = _rand(-600, 600)
+    ball_z = _rand(900, 1400)
+    bvx = _rand(-200, 200)
+    bvy = _rand(-200, 200)
+    bvz = _rand(150, 450)
+
+    car_state = CarState(
+        physics=Physics(
+            location=Vector3(car_x, car_y, car_z),
+            rotation=Rotator(0.0, 0.0, 0.0),
+            velocity=Vector3(0, 0, 0),
+        ),
+        boost_amount=100,
+    )
+    ball_state = BallState(
+        physics=Physics(
+            location=Vector3(ball_x, ball_y, ball_z),
+            velocity=Vector3(bvx, bvy, bvz),
+        )
+    )
+    agent.set_game_state(GameState(ball=ball_state, cars={agent.index: car_state}))
+
+
+def inject_double_tap(agent):
+    team = agent.team
+    ball_x = _rand(-700, 700)
+    ball_y = 5000 * (-1 if team == 0 else 1)
+    ball_z = _rand(1200, 1600)
+    bvy = -800 * (-1 if team == 0 else 1)  # bounce off backboard
+    car_x = ball_x + _rand(-800, 800)
+    car_y = ball_y - _rand(1000, 1600)
+    car_z = _rand(50, 150)
+    car_state = CarState(
+        physics=Physics(
+            location=Vector3(car_x, car_y, car_z),
+            rotation=Rotator(0, 0, 0),
+            velocity=Vector3(0, 0, 0),
+        ),
+        boost_amount=80,
+    )
+    ball_state = BallState(
+        physics=Physics(
+            location=Vector3(ball_x, ball_y, ball_z),
+            velocity=Vector3(0, bvy, _rand(-150, 50)),
+        )
+    )
+    agent.set_game_state(GameState(ball=ball_state, cars={agent.index: car_state}))
+
+
+def inject_flip_reset(agent):
+    team = agent.team
+    car_x = _rand(-1200, 1200)
+    car_y = _rand(-1500, -400) if team == 0 else _rand(400, 1500)
+    if team == 1:
+        car_y *= -1
+    car_z = _rand(400, 700)
+    ball_x = car_x + _rand(-150, 150)
+    ball_y = car_y + _rand(500, 900) * (-1 if team == 0 else 1)
+    ball_z = _rand(900, 1200)
+    car_state = CarState(
+        physics=Physics(
+            location=Vector3(car_x, car_y, car_z),
+            rotation=Rotator(0, 0, 0),
+            velocity=Vector3(0, 0, 0),
+        ),
+        boost_amount=100,
+    )
+    ball_state = BallState(
+        physics=Physics(
+            location=Vector3(ball_x, ball_y, ball_z),
+            velocity=Vector3(_rand(-150, 150), _rand(-150, 150), _rand(-150, 50)),
+        )
+    )
+    agent.set_game_state(GameState(ball=ball_state, cars={agent.index: car_state}))
+
+
+def inject_ceiling_shot(agent):
+    team = agent.team
+    car_x = _rand(-1200, 1200)
+    car_y = _rand(-400, 400) * (-1 if team == 0 else 1)
+    car_z = 1950  # near ceiling with contact
+    ball_x = car_x + _rand(-500, 500)
+    ball_y = car_y + _rand(800, 1400) * (-1 if team == 0 else 1)
+    ball_z = _rand(800, 1200)
+    car_state = CarState(
+        physics=Physics(
+            location=Vector3(car_x, car_y, car_z),
+            rotation=Rotator(0.0, 0.0, 0.0),
+            velocity=Vector3(0, 0, 0),
+        ),
+        boost_amount=60,
+    )
+    ball_state = BallState(
+        physics=Physics(
+            location=Vector3(ball_x, ball_y, ball_z),
+            velocity=Vector3(_rand(-100, 100), _rand(-100, 100), _rand(-50, 150)),
+        )
+    )
+    agent.set_game_state(GameState(ball=ball_state, cars={agent.index: car_state}))
+
+
+def inject_dribble_flick(agent):
+    team = agent.team
+    car_x = _rand(-800, 800)
+    car_y = _rand(-1400, -800) if team == 0 else _rand(800, 1400)
+    if team == 1:
+        car_y *= -1
+    car_z = _rand(40, 60)
+    ball_x = car_x + _rand(-50, 50)
+    ball_y = car_y + _rand(-50, 50)
+    ball_z = _rand(70, 120)
+    car_state = CarState(
+        physics=Physics(
+            location=Vector3(car_x, car_y, car_z),
+            rotation=Rotator(0, 0, 0),
+            velocity=Vector3(0, 0, 0),
+        ),
+        boost_amount=30,
+    )
+    ball_state = BallState(
+        physics=Physics(
+            location=Vector3(ball_x, ball_y, ball_z),
+            velocity=Vector3(0, 0, 0),
+        )
+    )
+    agent.set_game_state(GameState(ball=ball_state, cars={agent.index: car_state}))
+
+
+def inject_shadow_defense(agent):
+    # place us between our goal and ball, at shadow distance
+    team = agent.team
+    goal_y = -5120 if team == 0 else 5120
+    ball_x = _rand(-1500, 1500)
+    ball_y = _rand(-1600, -800) if team == 0 else _rand(800, 1600)
+    if team == 1:
+        ball_y *= -1
+    ball_z = _rand(80, 200)
+    # our position ~1200 behind the ball toward our goal
+    shadow_y = ball_y + (goal_y - ball_y) * 0.3
+    car_x = ball_x + _rand(-200, 200)
+    car_y = shadow_y
+    car_z = _rand(40, 60)
+    car_state = CarState(
+        physics=Physics(
+            location=Vector3(car_x, car_y, car_z),
+            rotation=Rotator(0, 0, 0),
+            velocity=Vector3(0, 0, 0),
+        ),
+        boost_amount=40,
+    )
+    ball_state = BallState(
+        physics=Physics(
+            location=Vector3(ball_x, ball_y, ball_z),
+            velocity=Vector3(_rand(-200, 200), _rand(-100, 100), 0),
+        )
+    )
+    agent.set_game_state(GameState(ball=ball_state, cars={agent.index: car_state}))
+
+

--- a/rewards_ssl.py
+++ b/rewards_ssl.py
@@ -1,34 +1,83 @@
+# rewards_ssl.py — SSL/pro shaping for mastery & reads
 import numpy as np
 
+
 DEFAULT_SSL_W = {
-    "ball_progress": 0.45, "touch_quality": 0.30,
-    "aerial_ctrl": 0.40, "gta_trans": 0.20,
-    "flip_reset": 0.30, "double_tap": 0.30,
-    "boost_pos": 0.18, "boost_neg": 0.10,
-    "shadow": 0.18, "overcommit": 0.28,
-    "kickoff": 0.22, "goal": 1.00, "concede": 1.00,
-    "bad_touches": 0.12, "idle": 0.05
+    # Core mastery
+    "speedflip": 0.25,
+    "adv_recovery": 0.25,
+    "fast_aerial": 0.30,
+    "wall_play": 0.20,
+    "dribble_carry": 0.25,
+    "flick_power": 0.30,
+    "shadow": 0.35,
+    "kickoff_win": 0.30,
+    # Advanced aerials
+    "air_dribble": 0.35,
+    "flip_reset": 0.40,
+    "ceiling_shot": 0.30,
+    "musty": 0.25,
+    "double_tap": 0.35,
+    # Ultra-efficient reads / movement
+    "zap_chain": 0.20,
+    "stall": 0.15,
+    "wavedash_flick": 0.20,
+    "deception": 0.20,
+    "perfect_touch": 0.40,
+    # General play
+    "ball_progress": 0.40,
+    "touch_quality": 0.30,
+    "boost_pos": 0.18,
+    "boost_neg": 0.10,
+    "overcommit": 0.28,
+    "goal": 1.00,
+    "concede": 1.00,
+    "idle": 0.05,
+    "kickoff": 0.22,
 }
+
 
 class SSLReward:
     def __init__(self, w=None):
         self.w = w or DEFAULT_SSL_W
 
     def __call__(self, info: dict) -> float:
-        g = self.w; r = 0.0
+        g = self.w
+        r = 0.0
+        # Core mastery
+        r += g["speedflip"] * info.get("kickoff_first_touch", 0.0)
+        r += g["adv_recovery"] * info.get("adv_recovery", 0.0)
+        r += g["fast_aerial"] * info.get("fast_aerial_attempt", 0.0)
+        r += g["wall_play"] * info.get("wall_play", 0.0)
+        r += g["dribble_carry"] * info.get("dribble_carry", 0.0)
+        r += g["flick_power"] * info.get("flick_power", 0.0)
+        r += g["shadow"] * info.get("shadow_good", 0.0)
+        r += g["kickoff_win"] * info.get("kickoff_score", 0.0)
+
+        # Advanced aerials
+        r += g["air_dribble"] * info.get("air_dribble_chain", 0.0)
+        r += g["flip_reset"] * info.get("flip_reset_attempt", 0.0)
+        r += g["ceiling_shot"] * info.get("ceiling_setup", 0.0)
+        r += g["musty"] * info.get("musty_attempt", 0.0)
+        r += g["double_tap"] * info.get("double_tap_attempt", 0.0)
+
+        # Ultra-efficient reads
+        r += g["zap_chain"] * info.get("zap_chain_dash", 0.0)
+        r += g["stall"] * info.get("stall_proxy", 0.0)
+        r += g["wavedash_flick"] * info.get("wavedash_flick", 0.0)
+        r += g["deception"] * info.get("deception_fake", 0.0)
+        r += g["perfect_touch"] * info.get("perfect_touch", 0.0)
+
+        # General play
         r += g["ball_progress"] * info.get("ball_to_opp_goal_cos", 0.0)
         r += g["touch_quality"] * info.get("ball_speed_gain_norm", 0.0)
-        r += g["aerial_ctrl"]  * info.get("aerial_alignment_cos", 0.0)
-        r += g["gta_trans"]    * info.get("gta_transition_flag", 0.0)
-        r += g["flip_reset"]   * info.get("flip_reset_attempt", 0.0)
-        r += g["double_tap"]   * info.get("double_tap_attempt", 0.0)
-        r += g["boost_pos"]    * info.get("boost_use_good", 0.0)
-        r -= g["boost_neg"]    * info.get("boost_waste", 0.0)
-        r += g["shadow"]       * info.get("shadow_angle_cos", 0.0)
-        r -= g["overcommit"]   * info.get("last_man_break_flag", 0.0)
-        r += g["kickoff"]      * info.get("kickoff_score", 0.0)
-        r += g["goal"]         * info.get("scored", 0.0)
-        r -= g["concede"]      * info.get("conceded", 0.0)
-        r -= g["bad_touches"]  * info.get("own_goal_touch", 0.0)
-        r -= g["idle"]         * info.get("idle_ticks", 0.0)
+        r += g["boost_pos"] * info.get("boost_use_good", 0.0)
+        r -= g["boost_neg"] * info.get("boost_waste", 0.0)
+        r -= g["overcommit"] * info.get("last_man_break_flag", 0.0)
+        r += g["kickoff"] * info.get("kickoff_score", 0.0)
+        r += g["goal"] * info.get("scored", 0.0)
+        r -= g["concede"] * info.get("conceded", 0.0)
+        r -= g["idle"] * info.get("idle_ticks", 0.0)
+
         return float(max(-1.0, min(1.0, r)))
+

--- a/simple_policy.py
+++ b/simple_policy.py
@@ -1,60 +1,53 @@
-# simple_policy.py — baseline 1v1 controller: intercept ball + aim through it toward opponent goal.
+# simple_policy.py — baseline 1v1 controller: intercept, carry, flick
 import numpy as np, math
 from rlbot.agents.base_agent import SimpleControllerState
 
+
 def _ang_norm(a):
-    # normalize to [-pi, pi]
-    while a > math.pi: a -= 2*math.pi
-    while a < -math.pi: a += 2*math.pi
+    while a > math.pi:
+        a -= 2 * math.pi
+    while a < -math.pi:
+        a += 2 * math.pi
     return a
 
-def _vec(x, y): return np.array([float(x), float(y)], dtype=np.float32)
+
+def _vec(x, y):
+    return np.array([float(x), float(y)], dtype=np.float32)
 
 
-def _yaw(rot): return float(rot.yaw)
+def _yaw(rot):
+    return float(rot.yaw)
+
 
 def _forward(rot):
-    # 2D forward on XY plane
     cy, sy = math.cos(rot.yaw), math.sin(rot.yaw)
     cp = math.cos(rot.pitch)
     return np.array([cp * cy, cp * sy], dtype=np.float32)
 
-def _speed_xy(v): return float(np.hypot(v.x, v.y))
-
-def _sign_to_opp(team):  # +Y towards orange goal, -Y towards blue goal
-    return -1.0 if team == 0 else 1.0
-
-def _aim_point(ball_loc, ball_vel, team, approach_dist=120.0):
-    # Place a point *behind* the ball along the line to opponent goal so we hit it toward their net.
-    goal = np.array([0.0, 5120.0 * _sign_to_opp(1-team)], dtype=np.float32)  # opponent goal center
-    b = _vec(ball_loc.x, ball_loc.y)
-    dir_to_goal = goal - b
-    n = np.linalg.norm(dir_to_goal) + 1e-6
-    back = b - dir_to_goal / n * approach_dist
-    return back
-
-def _predict_ball(ball_loc, ball_vel, t):
-    return _vec(ball_loc.x + ball_vel.x * t, ball_loc.y + ball_vel.y * t)
 
 class HeuristicBrain:
-    """
-    Produces an 8-dim action vector [steer, throttle, pitch, yaw, roll, jump, boost, handbrake]
-    which gets converted to SimpleControllerState by your to_controller().
-    """
     def __init__(self):
-        # Tunables
-        self.kp = 2.2            # steering P gain
-        self.kd = 0.7            # steering D gain on yaw rate
-        self.handbrake_thresh = 1.2  # rad; use powerslide when angle is large & close
-        self.align_boost_thresh = 0.30 # rad; boost when well aligned
-        self.flip_jump_speed = 1800.0  # consider a forward flip when slow & far
+        self.kp = 2.2
+        self.kd = 0.7
+        self.handbrake_thresh = 1.2
+        self.align_boost_thresh = 0.30
+        self.flip_jump_speed = 1800.0
         self.flip_dist = 2200.0
+        self._carry_ticks = 0
+        self._last_jump_time = 0.0
+
+    def _aim_point(self, ball_loc, team, approach_dist=140.0):
+        goal_y = 5120.0 if team == 1 else -5120.0
+        goal = np.array([0.0, goal_y], dtype=np.float32)
+        b = _vec(ball_loc.x, ball_loc.y)
+        d = goal - b
+        n = np.linalg.norm(d) + 1e-6
+        return b - d / n * approach_dist
 
     def action(self, packet, index) -> np.ndarray:
         me = packet.game_cars[index]
         ball = packet.game_ball
         team = me.team
-
         my_pos = _vec(me.physics.location.x, me.physics.location.y)
         my_yaw = _yaw(me.physics.rotation)
         my_fwd = _forward(me.physics.rotation)
@@ -62,49 +55,60 @@ class HeuristicBrain:
         my_speed = float(np.linalg.norm(my_vel))
         yaw_rate = float(getattr(me.physics.angular_velocity, "z", 0.0))
 
-        # Simple time-to-intercept guess and aim
-        dist = float(np.linalg.norm(_vec(ball.physics.location.x, ball.physics.location.y) - my_pos))
-        # Choose a lookahead proportional to distance but capped to keep it sane
-        t_look = max(0.05, min(1.2, dist / max(1200.0, my_speed + 400.0)))
-        target_ball = _predict_ball(ball.physics.location, ball.physics.velocity, t_look)
-        aim = _aim_point(ball.physics.location, ball.physics.velocity, team, approach_dist=140.0)
+        ball_pos = _vec(ball.physics.location.x, ball.physics.location.y)
+        ball_vel = _vec(ball.physics.velocity.x, ball.physics.velocity.y)
+        dist = float(np.linalg.norm(ball_pos - my_pos))
 
-        # Blend: mostly aim-behind-ball, but slightly toward predicted position for dynamic approach
-        target = 0.75 * aim + 0.25 * target_ball
+        # carry detection
+        under_ball = (
+            abs(ball.physics.location.x - me.physics.location.x) < 120
+            and abs(ball.physics.location.y - me.physics.location.y) < 120
+            and 60 < (ball.physics.location.z - me.physics.location.z) < 220
+            and np.linalg.norm(ball_vel) < 1200
+            and my_speed < 1700
+        )
+        self._carry_ticks = self._carry_ticks + 1 if under_ball else 0
+        carrying = self._carry_ticks > 10
 
-        to_target = target - my_pos
-        target_yaw = math.atan2(to_target[1], to_target[0])
-        ang_err = _ang_norm(target_yaw - my_yaw)  # desired steering angle
+        # target point
+        aim = self._aim_point(ball.physics.location, team, 140.0)
+        target = 0.75 * aim + 0.25 * ball_pos
+
+        # steering
+        tgt_yaw = math.atan2(target[1] - my_pos[1], target[0] - my_pos[0])
+        ang_err = _ang_norm(tgt_yaw - my_yaw)
         steer = np.clip(self.kp * ang_err - self.kd * yaw_rate, -1.0, 1.0)
 
-        # Throttle logic
-        throttle = 1.0
-        reverse = False
-        if abs(ang_err) > 2.35:  # ~135 deg wrong way; back up instead of endless circles
-            reverse = True
-        if reverse:
-            throttle = -0.5
-        # Handbrake for tight turns when close AND big angle
+        # throttle / boost / hb
+        throttle = -0.5 if abs(ang_err) > 2.35 else 1.0
         handbrake = 1.0 if (abs(ang_err) > self.handbrake_thresh and dist < 1500.0) else 0.0
-
-        # Boost when aligned and not already fast
         boost = 1.0 if (abs(ang_err) < self.align_boost_thresh and my_speed < 2200.0) else 0.0
 
-        # Simple jump / double jump for high balls in front
+        # jump/flick: if carrying and roughly aligned, execute pop
         jump = 0.0
-        if ball.physics.location.z > 420 and abs(ang_err) < 0.35 and dist < 1000.0:
+        if carrying and abs(ang_err) < 0.35:
             jump = 1.0
 
-        # Opportunistic forward flip when far and slow but aligned
-        if dist > self.flip_dist and my_speed < self.flip_jump_speed and abs(ang_err) < 0.20:
-            jump = 1.0  # one-tap; your speedflip code will handle KO; this is mid-field burst
+        # long flip when far & slow & aligned
+        if (
+            dist > self.flip_dist
+            and my_speed < self.flip_jump_speed
+            and abs(ang_err) < 0.20
+            and not carrying
+        ):
+            jump = 1.0
 
-        # Map to 8-dim action
-        a = np.array([
-            float(steer), float(throttle),
-            0.0, 0.0, 0.0,               # pitch,yaw,roll (not used by ground controller)
-            float(jump),
-            float(boost),
-            float(handbrake)
-        ], dtype=np.float32)
-        return a
+        return np.array(
+            [
+                float(steer),
+                float(throttle),
+                0.0,
+                0.0,
+                0.0,
+                float(jump),
+                float(boost),
+                float(handbrake),
+            ],
+            dtype=np.float32,
+        )
+


### PR DESCRIPTION
## Summary
- add heuristic telemetry for SSL mechanics
- add curriculum drills for advanced mechanics
- refine rewards and fallback controller for dribble/flicks

## Testing
- `python -m py_compile mechanics_ssl.py drills_ssl.py rewards_ssl.py simple_policy.py bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68b7f03b518c8323af73b3a25a3f49ee