### PR TITLE
Add SSL awareness and intent decision layer

### DIFF
--- a/awareness_ssl.py
+++ b/awareness_ssl.py
@@ -1,0 +1,150 @@
+import math, numpy as np
+
+SUP = 2300.0  # supersonic speed cap (uu/s) for quick ETAs
+
+# Big boost pad rough world coords (Psyonix standard)
+BIG_BOOSTS = [
+    np.array([-3072.0, -4096.0, 0.0], dtype=np.float32),
+    np.array([ 3072.0, -4096.0, 0.0], dtype=np.float32),
+    np.array([-3072.0,  4096.0, 0.0], dtype=np.float32),
+    np.array([ 3072.0,  4096.0, 0.0], dtype=np.float32),
+]
+
+def _v3(obj):
+    return np.array([float(obj.x), float(obj.y), float(obj.z)], dtype=np.float32)
+
+def _norm(v): 
+    n = float(np.linalg.norm(v))
+    return max(n, 1e-6)
+
+def _eta(p_from, p_to, cur_speed=0.0):
+    # Approx ETA: distance / max(supersonic, current+some accel)
+    d = _norm(p_to - p_from)
+    v = max(1200.0, min(SUP, cur_speed + 800.0))  # simple accel cushion
+    return d / v
+
+def _sign_to_opp(team):  # +Y toward orange when we are blue; -Y toward blue when we are orange
+    return -1.0 if team == 0 else 1.0
+
+def nearest_big_boost(my_pos, team):
+    # prefer our half if close decision
+    target = None; best = 1e9
+    half_sign = -1.0 if team == 0 else 1.0
+    for b in BIG_BOOSTS:
+        if math.copysign(1.0, b[1]) == half_sign:  # our half first
+            d = _norm(b - my_pos)
+            if d < best:
+                best, target = d, b
+    if target is None:
+        for b in BIG_BOOSTS:
+            d = _norm(b - my_pos)
+            if d < best:
+                best, target = d, b
+    return target
+
+def compute_context(packet, index):
+    """Returns a dict with awareness signals + recommended intent skeleton (string).
+       Robust to missing fields; never raises."""
+    ctx = {}
+    try:
+        me = packet.game_cars[index]
+        opp = next(c for i,c in enumerate(packet.game_cars) if i != index and c.team != me.team and not c.is_demolished)
+    except Exception:
+        opp = None
+    try:
+        ball = packet.game_ball
+        gi = packet.game_info
+    except Exception:
+        return ctx
+
+    my_p = _v3(me.physics.location)
+    my_v = _v3(me.physics.velocity); my_s = _norm(my_v)
+    my_b = float(getattr(me, "boost", 33.0))
+    team = me.team
+
+    b_p = _v3(ball.physics.location)
+    b_v = _v3(ball.physics.velocity)
+    opp_p = _v3(opp.physics.location) if opp else np.array([0.0, 0.0, 0.0], dtype=np.float32)
+    opp_v = _v3(opp.physics.velocity) if opp else np.array([0.0, 0.0, 0.0], dtype=np.float32)
+    opp_s = _norm(opp_v)
+
+    # ETAs to ball & to our back-post (rough)
+    eta_me_ball = _eta(my_p, b_p, my_s)
+    eta_opp_ball = _eta(opp_p, b_p, opp_s) if opp is not None else 9e9
+
+    own_goal = np.array([0.0, -5120.0 if team == 0 else 5120.0, 0.0], dtype=np.float32)
+    back_post = np.array([-900.0, own_goal[1], 0.0], dtype=np.float32) if b_p[0] < 0 else np.array([900.0, own_goal[1], 0.0], dtype=np.float32)
+    eta_me_back = _eta(my_p, back_post, my_s)
+
+    # Ball movement toward opponent / our goal (cosine)
+    to_opp_sign = _sign_to_opp(team)
+    b_dir = b_v[:2]; goal_vec_opp = np.array([0.0, 1.0 * to_opp_sign], dtype=np.float32)
+    ball_dir_cos_opp = float(np.dot(b_dir[:2], goal_vec_opp) / (_norm(b_dir[:2]) * _norm(goal_vec_opp)))
+    ball_dir_cos_opp = 0.0 if math.isnan(ball_dir_cos_opp) else max(-1.0, min(1.0, ball_dir_cos_opp))
+
+    # Simple-half checks
+    in_opp_half = (b_p[1] * to_opp_sign) > 0.0
+    in_own_half = not in_opp_half
+
+    # Possession proxy: closer ETA and ball slow
+    possession = float(eta_me_ball < eta_opp_ball and _norm(b_v) < 1800.0)
+
+    # Pressure & threat
+    pressure_raw = 0.0
+    if in_opp_half:
+        pressure_raw = 0.5 + 0.5 * max(0.0, ball_dir_cos_opp)  # prefer moving toward their goal
+        if eta_me_ball < eta_opp_ball + 0.2:
+            pressure_raw = min(1.0, pressure_raw + 0.3)
+    threat_raw = 0.0
+    if in_own_half:
+        toward_own = 1.0 if ball_dir_cos_opp < 0 else 0.0
+        faster_opp = 1.0 if eta_opp_ball + 0.1 < eta_me_ball else 0.0
+        threat_raw = max(toward_own, faster_opp)
+
+    # Overcommit & recovery quality
+    try:
+        lm_break = 1.0 if ( (b_p[1] * to_opp_sign) < (my_p[1] * to_opp_sign) and my_b < 15.0 and threat_raw > 0.5 ) else 0.0
+    except Exception:
+        lm_break = 0.0
+    recovery_ok = float(eta_me_back < max(0.8, 1.2 * eta_opp_ball) or pressure_raw > 0.7)
+
+    # Risk budget: when behind late or with high boost, allow more risk
+    time_left = max(0.0, 300.0 - float(getattr(gi, "seconds_elapsed", 0.0)) % 300.0)
+    my_team_score = packet.teams[team].score
+    their_score = packet.teams[1 - team].score
+    losing = 1.0 if my_team_score + 0.5 < their_score else 0.0
+    risk = float(0.2 + 0.5 * (my_b / 100.0) + 0.3 * losing + (0.2 if time_left < 60.0 else 0.0))
+    risk = max(0.0, min(1.0, risk))
+
+    # Recommend a high-level intent
+    intent = "PRESS"
+    if threat_raw > 0.6 and not recovery_ok:
+        intent = "SHADOW"
+    elif my_b < 20.0 and pressure_raw < 0.5 and eta_me_ball > 0.7:
+        intent = "BOOST"
+    elif possession:
+        intent = "DRIBBLE"   # set up intentional touch/flick
+    elif pressure_raw > 0.7 and eta_me_ball < eta_opp_ball:
+        intent = "CHALLENGE"
+    elif in_opp_half and ball_dir_cos_opp > 0.4:
+        intent = "SHOOT"
+    elif threat_raw > 0.3:
+        intent = "CLEAR"
+    # Allow riskier choices when risk high
+    if risk > 0.7 and intent in ("DRIBBLE","PRESS") and in_opp_half:
+        intent = "FAKE" if np.linalg.norm(b_v) < 900.0 else "CHALLENGE"
+
+    ctx.update(dict(
+        pressure_idx=float(max(0.0, min(1.0, pressure_raw))),
+        threat_idx=float(max(0.0, min(1.0, threat_raw))),
+        possession_idx=possession,
+        recovery_ok=recovery_ok,
+        overcommit_flag=lm_break,
+        risk_budget=risk,
+        eta_me_ball=eta_me_ball,
+        eta_opp_ball=eta_opp_ball,
+        eta_me_back=eta_me_back,
+        intent=intent,
+        nearest_big_boost=nearest_big_boost(my_p, team),
+    ))
+    return ctx

--- a/decision_head.py
+++ b/decision_head.py
@@ -1,0 +1,58 @@
+# decision_head.py — intent guards that shape/control actions
+import numpy as np
+
+INTENTS = {"PRESS","CONTROL","CHALLENGE","SHADOW","BOOST","CLEAR","DRIBBLE","SHOOT","FAKE","ROTATE_BACK_POST"}
+
+def guard_by_intent(intent: str, action: np.ndarray, ctx: dict) -> np.ndarray:
+    """
+    Modify the 8-dim action vector to enforce high-level decisions.
+    action = [steer, throttle, pitch, yaw, roll, jump, boost, handbrake]
+    """
+    a = action.copy().astype(np.float32)
+    intent = (intent or "PRESS").upper()
+    risk = float(ctx.get("risk_budget", 0.3))
+
+    # Conservative clamps when defending / low recovery quality
+    if intent in ("SHADOW","ROTATE_BACK_POST"):
+        a[6] = 0.0  # boost off
+        a[1] = float(np.clip(a[1], 0.4, 0.9))  # modest throttle forward
+        a[7] = 0.0  # no powerslide spam
+        a[5] = 0.0  # no jumps
+        return a
+
+    # Go grab boost
+    if intent == "BOOST":
+        a[6] = 1.0            # boost on
+        a[5] = 0.0            # no jumps
+        a[7] = 0.0            # no drift
+        a[1] = 1.0            # full throttle
+        return a
+
+    # Challenge = decisive approach (less handbrake), allow boost if aligned
+    if intent == "CHALLENGE":
+        a[7] = 0.0
+        a[6] = max(a[6], 0.7)
+        a[1] = 1.0
+        return a
+
+    # Control/Dribble = gentle throttle; no random jumps; keep boost mostly off
+    if intent in ("CONTROL","DRIBBLE"):
+        a[1] = float(np.clip(a[1], 0.2, 0.8))
+        a[6] = float(np.clip(a[6], 0.0, 0.3))
+        a[5] = float(np.clip(a[5], 0.0, 0.5))
+        return a
+
+    # Shoot / Clear = allow more boost; jumps allowed
+    if intent in ("SHOOT","CLEAR","PRESS"):
+        a[6] = max(a[6], 0.5 if intent=="CLEAR" else 0.8)
+        a[1] = 1.0
+        return a
+
+    # Fake = kill throttle/boost briefly (deception window handled elsewhere)
+    if intent == "FAKE":
+        a[1] = min(a[1], 0.2)
+        a[6] = 0.0
+        a[5] = 0.0
+        return a
+
+    return a

--- a/rewards_ssl.py
+++ b/rewards_ssl.py
@@ -34,6 +34,10 @@ DEFAULT_SSL_W = {
     "concede": 1.00,
     "idle": 0.05,
     "kickoff": 0.22,
+    "pressure_awareness": 0.25,
+    "possession_awareness": 0.20,
+    "recovery_ok": 0.20,
+    "overcommit_flag_pen": 0.35,
 }
 
 
@@ -78,6 +82,12 @@ class SSLReward:
         r += g["goal"] * info.get("scored", 0.0)
         r -= g["concede"] * info.get("conceded", 0.0)
         r -= g["idle"] * info.get("idle_ticks", 0.0)
+
+        # Awareness taps
+        r += g["pressure_awareness"]   * info.get("pressure_idx", 0.0)
+        r += g["possession_awareness"] * info.get("possession_idx", 0.0)
+        r += g["recovery_ok"]          * (1.0 if info.get("recovery_ok", False) else 0.0)
+        r -= g["overcommit_flag_pen"]  * info.get("overcommit_flag", 0.0)
 
         return float(max(-1.0, min(1.0, r)))
 

--- a/simple_policy.py
+++ b/simple_policy.py
@@ -44,7 +44,7 @@ class HeuristicBrain:
         n = np.linalg.norm(d) + 1e-6
         return b - d / n * approach_dist
 
-    def action(self, packet, index) -> np.ndarray:
+    def action(self, packet, index, intent: str = None) -> np.ndarray:
         me = packet.game_cars[index]
         ball = packet.game_ball
         team = me.team
@@ -98,7 +98,7 @@ class HeuristicBrain:
         ):
             jump = 1.0
 
-        return np.array(
+        a = np.array(
             [
                 float(steer),
                 float(throttle),
@@ -111,4 +111,15 @@ class HeuristicBrain:
             ],
             dtype=np.float32,
         )
+
+        # Intent shaping (lightweight): SHADOW/BOOST/DRIBBLE
+        if intent:
+            up = intent.upper()
+            if up == "SHADOW":
+                a[6] = 0.0; a[1] = max(0.5, a[1]); a[7] = 0.0; a[5] = 0.0
+            elif up == "BOOST":
+                a[1] = 1.0; a[6] = 1.0; a[5] = 0.0; a[7] = 0.0
+            elif up in ("DRIBBLE","CONTROL"):
+                a[1] = min(a[1], 0.7); a[6] = min(a[6], 0.3); a[5] = min(a[5], 0.5)
+        return a
 


### PR DESCRIPTION
## Summary
- Compute game context (pressure, threat, possession, recovery, risk) and recommend high-level intents
- Guard action outputs with intent-specific clamps
- Shape heuristic policy and rewards using awareness signals
- Route context through bot for intent-based control and HUD display

## Testing
- `python -m py_compile awareness_ssl.py decision_head.py simple_policy.py rewards_ssl.py bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68b7f15cb9b88323ad50a955d2da0221