### PR TITLE
Integrate recovery mechanics and telemetry

### DIFF
--- a/drills_ssl.py
+++ b/drills_ssl.py
@@ -176,3 +176,65 @@ def inject_shadow_defense(agent):
     agent.set_game_state(GameState(ball=ball_state, cars={agent.index: car_state}))
 
 
+def inject_half_flip(agent):
+    # Car facing away from ball, low speed
+    team = agent.team
+    car_x = _rand(-800, 800)
+    car_y = _rand(-1200, -600) if team==0 else _rand(600, 1200)
+    if team==1: car_y *= -1
+    ball_x = car_x + _rand(-200, 200)
+    ball_y = car_y + (800 * (-1 if team==0 else 1))
+    car_state = CarState(physics=Physics(location=Vector3(car_x, car_y, 50),
+                                         rotation=Rotator(0, _rand(-3.0, 3.0), 0),
+                                         velocity=Vector3(0, 0, 0)), boost_amount=20)
+    ball_state = BallState(physics=Physics(location=Vector3(ball_x, ball_y, 120)))
+    agent.set_game_state(GameState(ball=ball_state, cars={agent.index: car_state}))
+
+
+def inject_wave_dash(agent):
+    # Small hop then land — encourage wave dash
+    team = agent.team
+    car_x = _rand(-1000, 1000)
+    car_y = _rand(-800, -200) if team==0 else _rand(200, 800)
+    if team==1: car_y *= -1
+    car_state = CarState(physics=Physics(location=Vector3(car_x, car_y, 70),
+                                         velocity=Vector3(_rand(-200,200), _rand(-200,200), -200)))
+    agent.set_game_state(GameState(cars={agent.index: car_state}))
+
+
+def inject_wall_nose_down(agent):
+    # Place on side wall and ask for nose-down landing
+    team = agent.team
+    x = 3000 if np.random.rand() < 0.5 else -3000
+    y = _rand(-2500, 2500)
+    car_state = CarState(physics=Physics(location=Vector3(x, y, 500),
+                                         rotation=Rotator(_rand(0.3,0.6), 0.0, _rand(-1.2,1.2)),
+                                         velocity=Vector3(0,0,-300)),
+                         boost_amount=0.0)
+    agent.set_game_state(GameState(cars={agent.index: car_state}))
+
+
+def inject_ceiling_reset(agent):
+    # Ceiling contact then drop
+    team = agent.team
+    x = _rand(-800, 800)
+    y = _rand(-500, 500) * (-1 if team==0 else 1)
+    car_state = CarState(physics=Physics(location=Vector3(x, y, 1980),
+                                         rotation=Rotator(0.0, 0.0, 0.0),
+                                         velocity=Vector3(0,0,0)),
+                         boost_amount=20)
+    agent.set_game_state(GameState(cars={agent.index: car_state}))
+
+
+def inject_net_ramp_pop(agent):
+    # Inside goal ramp, encourage ramp pop/reset
+    team = agent.team
+    y = -5050 if team==0 else 5050
+    x = _rand(-700, 700)
+    car_state = CarState(physics=Physics(location=Vector3(x, y, 120),
+                                         rotation=Rotator(0.0, 0.0, 0.0),
+                                         velocity=Vector3(0,0,50)),
+                         boost_amount=0.0)
+    agent.set_game_state(GameState(cars={agent.index: car_state}))
+
+

--- a/recovery.py
+++ b/recovery.py
@@ -1,0 +1,125 @@
+# recovery.py — recovery controller (air-roll to wheels, wave dash, half-flip)
+import math, numpy as np
+from rlbot.agents.base_agent import SimpleControllerState
+
+
+def _ang_norm(a):
+    while a > math.pi: a -= 2*math.pi
+    while a < -math.pi: a += 2*math.pi
+    return a
+
+
+def _speed_xy(v): return float(math.hypot(v.x, v.y))
+
+
+def _face_target_yaw(me, x, y):
+    yaw = float(me.physics.rotation.yaw)
+    ang = _ang_norm(math.atan2(y - me.physics.location.y, x - me.physics.location.x) - yaw)
+    return float(np.clip(2.2*ang - 0.7*getattr(me.physics.angular_velocity, "z", 0.0), -1.0, 1.0))
+
+
+class RecoveryBrain:
+    """
+    Returns (active: bool, action: np.ndarray[8]) when recovery logic should override.
+    Implements:
+      - air-roll to wheels & nose-down landings (ground / wall)
+      - wave dash on landing window for speed
+      - half-flip when facing away and need to reverse direction quickly
+    """
+    def __init__(self):
+        self._land_t0 = 0.0
+        self._do_wavedash = False
+        self._hf_state = "idle"
+        self._hf_t0 = 0.0
+
+    def _is_airborne(self, me):
+        try:
+            return (not me.has_wheel_contact) and me.physics.location.z > 70
+        except Exception:
+            return me.physics.location.z > 70
+
+    def _near_ground(self, me):
+        return me.physics.location.z < 100
+
+    def _half_flip_needed(self, me, ball):
+        # Need to turn around fast: ball roughly behind us and our forward speed small
+        my = me.physics
+        yaw = my.rotation.yaw
+        dx = ball.physics.location.x - my.location.x
+        dy = ball.physics.location.y - my.location.y
+        ang = abs(_ang_norm(math.atan2(dy, dx) - yaw))
+        vxy = _speed_xy(my.velocity)
+        return ang > 2.2 and vxy < 700  # ~ >126° and we're slow
+
+    def _run_half_flip(self, t):
+        """
+        Simple half-flip macro timeline (seconds since start):
+          0.00-0.08: first jump, pitch back
+          0.14-0.22: second jump to cancel, air-roll to flatten
+          0.28-0.60: pitch forward to drive away
+        Output: 8-dim action
+        """
+        a = np.zeros(8, dtype=np.float32)
+        # steer, throttle, pitch, yaw, roll, jump, boost, handbrake
+        a[1] = 1.0
+        if 0.00 <= t < 0.08:
+            a[5] = 1.0; a[2] = -1.0
+        elif 0.14 <= t < 0.22:
+            a[5] = 1.0; a[4] = 1.0  # air-roll right to flatten
+        elif 0.22 <= t < 0.32:
+            a[2] = 1.0
+        return a
+
+    def act(self, packet, index, intent=None):
+        """
+        Return (active, action8). If active is True, caller should use this action.
+        """
+        me = packet.game_cars[index]
+        ball = packet.game_ball
+        gi = packet.game_info
+        now = float(getattr(gi, "seconds_elapsed", 0.0))
+
+        # --- Half-flip finite state machine
+        if self._hf_state == "idle":
+            if self._half_flip_needed(me, ball):
+                self._hf_state = "do"
+                self._hf_t0 = now
+        if self._hf_state == "do":
+            t = now - self._hf_t0
+            a = self._run_half_flip(t)
+            if t > 0.60:
+                self._hf_state = "idle"
+            return True, a
+
+        # --- Airborne recovery
+        airborne = self._is_airborne(me)
+        if airborne:
+            a = np.zeros(8, dtype=np.float32)
+            a[6] = 0.0  # no boost while stabilizing
+            # Try to orient nose-down (pitch forward) and roll to wheels
+            a[2] = 0.6   # pitch forward
+            a[4] = 0.4 if me.physics.rotation.roll < 0 else -0.4  # roll toward upright
+            # slight yaw toward ball to be pre-aligned on landing
+            steer = _face_target_yaw(me, ball.physics.location.x, ball.physics.location.y)
+            a[0] = float(np.clip(0.5*steer, -1.0, 1.0))
+            # Set up wave-dash flag when near ground & descending
+            if self._near_ground(me) and me.physics.velocity.z < -200:
+                self._land_t0 = now
+                self._do_wavedash = True
+            return True, a
+
+        # --- On/near ground: wave dash window
+        if self._do_wavedash:
+            t = now - self._land_t0
+            a = np.zeros(8, dtype=np.float32)
+            a[1] = 1.0
+            if 0.04 < t < 0.12:       # quick jump
+                a[5] = 1.0
+            elif 0.12 <= t < 0.24:    # pitch forward to dash
+                a[2] = 1.0
+            else:
+                self._do_wavedash = False
+            return True, a
+
+        # No special recovery needed
+        return False, np.zeros(8, dtype=np.float32)

--- a/rewards_ssl.py
+++ b/rewards_ssl.py
@@ -38,6 +38,14 @@ DEFAULT_SSL_W = {
     "possession_awareness": 0.20,
     "recovery_ok": 0.20,
     "overcommit_flag_pen": 0.35,
+    # Recovery mastery weights
+    "recovery_mastery": 0.45,
+    "air_roll_landing_w": 0.25,
+    "wave_dash_w": 0.25,
+    "half_flip_w": 0.25,
+    "ceiling_reset_w": 0.15,
+    "net_ramp_reset_w": 0.10,
+    "wall_nose_down_w": 0.15,
 }
 
 
@@ -88,6 +96,15 @@ class SSLReward:
         r += g["possession_awareness"] * info.get("possession_idx", 0.0)
         r += g["recovery_ok"]          * (1.0 if info.get("recovery_ok", False) else 0.0)
         r -= g["overcommit_flag_pen"]  * info.get("overcommit_flag", 0.0)
+
+        # Recovery mastery
+        r += g["recovery_mastery"]   * info.get("recovery_mastery", 0.0)
+        r += g["air_roll_landing_w"] * info.get("air_roll_landing", 0.0)
+        r += g["wave_dash_w"]        * info.get("wave_dash_exec", 0.0)
+        r += g["half_flip_w"]        * info.get("half_flip_exec", 0.0)
+        r += g["ceiling_reset_w"]    * info.get("ceiling_reset_exec", 0.0)
+        r += g["net_ramp_reset_w"]   * info.get("net_ramp_reset_exec", 0.0)
+        r += g["wall_nose_down_w"]   * info.get("wall_nose_down", 0.0)
 
         return float(max(-1.0, min(1.0, r)))
 


### PR DESCRIPTION
## Summary
- Add RecoveryBrain for air-roll landings, wave dashes, and half-flips
- Track recovery mastery in telemetry, rewards, and drills
- Bias heuristic policy toward wavedashing after landing and wire recovery override into action pipeline

## Testing
- `python -m py_compile recovery.py mechanics_ssl.py drills_ssl.py rewards_ssl.py simple_policy.py bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68b7f364a9f08323b304ba1573752e39