### PR TITLE
feat: tune 1s profile and new intents

### DIFF
--- a/boost_pathing.py
+++ b/boost_pathing.py
@@ -1,0 +1,28 @@
+# boost_pathing.py — tiny small-pad planner for 1s
+import numpy as np
+
+# XY coords of key small pads (subset to keep tight)
+SMALL_PADS = np.array([
+    [-2048, -2560], [0, -2560], [2048, -2560],
+    [-2560, 0],     [2560, 0],
+    [-2048, 2560],  [0, 2560],  [2048, 2560],
+    [-1000, -1000], [1000, -1000], [-1000, 1000], [1000, 1000],
+], dtype=np.float32)
+
+def nearest_small_pad_xy(x, y, prefer_half_sign=None):
+    p = np.array([x, y], dtype=np.float32)
+    pads = SMALL_PADS
+    if prefer_half_sign is not None:
+        pads = pads[np.sign(pads[:,1]) == prefer_half_sign]
+        if pads.size == 0: pads = SMALL_PADS
+    i = int(np.argmin(np.linalg.norm(pads - p, axis=1)))
+    return pads[i]
+
+def football_lane(x, y, to_defense=False):
+    # quick “football route” selection: towards own half if defending, else toward opp half
+    p = np.array([x, y], dtype=np.float32)
+    if to_defense:
+        target = nearest_small_pad_xy(p[0], -4096 if y > 0 else 4096, prefer_half_sign=-np.sign(y) if y != 0 else None)
+    else:
+        target = nearest_small_pad_xy(p[0],  4096 if y < 0 else -4096, prefer_half_sign=np.sign(-y) if y != 0 else None)
+    return target

--- a/decision_head.py
+++ b/decision_head.py
@@ -1,7 +1,7 @@
 # decision_head.py — intent guards that shape/control actions
 import numpy as np
 
-INTENTS = {"PRESS","CONTROL","CHALLENGE","SHADOW","BOOST","CLEAR","DRIBBLE","SHOOT","FAKE","ROTATE_BACK_POST"}
+INTENTS = {"PRESS","CONTROL","CHALLENGE","SHADOW","BOOST","CLEAR","DRIBBLE","SHOOT","FAKE","ROTATE_BACK_POST","STARVE","BUMP"}
 
 def guard_by_intent(intent: str, action: np.ndarray, ctx: dict) -> np.ndarray:
     """
@@ -26,6 +26,16 @@ def guard_by_intent(intent: str, action: np.ndarray, ctx: dict) -> np.ndarray:
         a[5] = 0.0            # no jumps
         a[7] = 0.0            # no drift
         a[1] = 1.0            # full throttle
+        return a
+
+    if intent == "STARVE":
+        # prioritize throttle, minimal jumps; conserve boost unless straight-line pad run
+        a[1] = 1.0; a[6] = float(min(a[6], 0.4)); a[5] = 0.0; a[7] = 0.0
+        return a
+
+    if intent == "BUMP":
+        # commit boost & throttle, no handbrake; allow jump only when near
+        a[1] = 1.0; a[6] = 1.0; a[7] = 0.0
         return a
 
     # Challenge = decisive approach (less handbrake), allow boost if aligned

--- a/mechanics_ssl.py
+++ b/mechanics_ssl.py
@@ -1,5 +1,7 @@
 # mechanics_ssl.py — SSL mechanics detectors / telemetry (best-effort heuristics)
 import math, numpy as np
+from ones_profile import ONES
+from boost_pathing import SMALL_PADS
 
 
 def _hyp2(x, y):
@@ -290,6 +292,16 @@ class SkillTelemetry:
             0.25 * info.get("half_flip_exec", 0.0) +
             0.10 * info.get("wall_nose_down", 0.0)
         )
+
+        # Small-pad pickup: if near any small-pad point this tick
+        pads = SMALL_PADS
+        p2 = np.array([my_loc.x, my_loc.y], dtype=np.float32)
+        close = np.min(np.linalg.norm(pads - p2, axis=1))
+        info["small_pad_pickup"] = 1.0 if close < ONES["pad_radius"] else 0.0
+
+        # Low-50 proxy: under-ball, we jump, ball stays low but gains forward speed
+        low50 = (under_ball and latest_touch_me and dz < 350 and abs(ball_vel.y) + abs(ball_vel.x) > 500)
+        info["low50_success"] = 1.0 if low50 else 0.0
 
         # store for next tick
         self._ball_speed_prev = ball_spd

--- a/ones_profile.py
+++ b/ones_profile.py
@@ -1,0 +1,12 @@
+# ones_profile.py — knobs for 1v1 profile
+ONES = {
+    "target_min_boost": 40,        # prefer to play on >= 40 boost (Scrub Killa advice)
+    "pad_radius": 220.0,           # proximity to count a small-pad pickup
+    "low50_distance": 260.0,       # when under-ball & close, bias to low-50
+    "back_post_buffer": 900.0,     # how far to favor back-post when defending
+    "demo_allow": True,
+    "demo_min_speed": 1800.0,      # need speed to threaten demo
+    "tempo_slow_lead_secs": 60.0,  # last minute: prefer control when leading
+    "tempo_slow_boost_edge": 20.0, # slow if we have +20 boost over opp
+    "starve_when_edge": 1,         # enable boost-starve routine when we have pressure/edge
+}

--- a/rewards_ssl.py
+++ b/rewards_ssl.py
@@ -46,6 +46,12 @@ DEFAULT_SSL_W = {
     "ceiling_reset_w": 0.15,
     "net_ramp_reset_w": 0.10,
     "wall_nose_down_w": 0.15,
+    "small_pads": 0.20,
+    "boost_delta": 0.15,
+    "possession_time": 0.25,
+    "low50": 0.30,
+    "back_post_cover": 0.25,
+    "demo_util": 0.25,
 }
 
 
@@ -105,6 +111,14 @@ class SSLReward:
         r += g["ceiling_reset_w"]    * info.get("ceiling_reset_exec", 0.0)
         r += g["net_ramp_reset_w"]   * info.get("net_ramp_reset_exec", 0.0)
         r += g["wall_nose_down_w"]   * info.get("wall_nose_down", 0.0)
+
+        # 1s-specific
+        r += g["small_pads"]       * info.get("small_pad_pickup", 0.0)
+        r += g["boost_delta"]      * max(0.0, info.get("boost_delta_norm", 0.0))
+        r += g["possession_time"]  * info.get("possession_ticks_norm", 0.0)
+        r += g["low50"]            * info.get("low50_success", 0.0)
+        r += g["back_post_cover"]  * info.get("back_post_ok", 0.0)
+        r += g["demo_util"]        * info.get("demo_benefit", 0.0)
 
         return float(max(-1.0, min(1.0, r)))
 


### PR DESCRIPTION
## Summary
- add ones_profile knobs and small-pad path planning
- extend awareness, decision head, policy, telemetry, rewards, and bot logic for 1v1 intents like STARVE and BUMP

## Testing
- `python -m py_compile ones_profile.py boost_pathing.py awareness_ssl.py decision_head.py simple_policy.py mechanics_ssl.py rewards_ssl.py bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68b800974eb0832387bd241c13a1adaf