### PR TITLE
Add aerial 1v1 air-dribble offense and backboard defense

### DIFF
--- a/aerial_play.py
+++ b/aerial_play.py
@@ -1,0 +1,126 @@
+# aerial_play.py — pro 1s aerial brains: wall→air-dribble (offense), backboard defense (saves)
+import math, numpy as np
+from rlbot.agents.base_agent import SimpleControllerState
+
+GRAV_Z = -650.0  # uu/s^2 Rocket League gravity (approx)
+
+def _clip(x, lo=-1.0, hi=1.0): return float(max(lo, min(hi, x)))
+def _v3(p): return np.array([float(p.x), float(p.y), float(p.z)], dtype=np.float32)
+
+def predict_ball_pos(ball, t):
+    p = _v3(ball.physics.location)
+    v = _v3(ball.physics.velocity)
+    a = np.array([0.0, 0.0, GRAV_Z], dtype=np.float32)
+    return p + v * t + 0.5 * a * (t ** 2)
+
+def backboard_intercept(ball, team, max_t=2.0):
+    # Find where ball hits/approaches backboard plane; return (pos, t)
+    y_board = -5120.0 if team == 0 else 5120.0
+    # scan small steps for first crossing toward our backboard
+    last_p = _v3(ball.physics.location); last_t = 0.0
+    for i in range(1, 61):
+        t = i * (max_t / 60.0)
+        p = predict_ball_pos(ball, t)
+        if (team == 0 and p[1] < y_board + 200.0) or (team == 1 and p[1] > y_board - 200.0):
+            # clamp to backboard face and keep z within arena
+            p[1] = y_board
+            p[0] = float(max(-1800.0, min(1800.0, p[0])))
+            p[2] = float(max(200.0, min(1800.0, p[2])))
+            return p, t
+        last_p = p; last_t = t
+    return None, None
+
+def steer_to(me, target_xy, yaw_gain=2.2, d_gain=0.7):
+    yaw = float(me.physics.rotation.yaw)
+    yaw_rate = float(getattr(me.physics.angular_velocity, "z", 0.0))
+    ang = math.atan2(target_xy[1] - me.physics.location.y, target_xy[0] - me.physics.location.x) - yaw
+    while ang > math.pi: ang -= 2*math.pi
+    while ang < -math.pi: ang += 2*math.pi
+    steer = _clip(yaw_gain * ang - d_gain * yaw_rate)
+    return steer, abs(ang)
+
+class AirDribbleBrain:
+    """
+    Minimal wall→air-dribble routine:
+      1) Route to side wall carry.
+      2) Pop ball up the wall, jump to chase.
+      3) Gentle boost taps + small pitch to keep ball on nose; aim through to goal.
+    """
+    def __init__(self): self.state = "route"; self.t0 = 0.0
+
+    def reset(self): self.state = "route"; self.t0 = 0.0
+
+    def act(self, packet, index, intent=None):
+        me = packet.game_cars[index]
+        ball = packet.game_ball
+        ctl = SimpleControllerState()
+        # choose sidewall: closer x side
+        side_x = 3000.0 if abs(me.physics.location.x) < abs(ball.physics.location.x) else (1500.0 if ball.physics.location.x >= 0 else -1500.0)
+        target_xy = np.array([side_x, float(ball.physics.location.y)], dtype=np.float32)
+
+        # Phase routing: go to sidewall line behind ball
+        steer, ang_abs = steer_to(me, target_xy)
+        ctl.steer = steer
+        ctl.throttle = 1.0
+        ctl.boost = 1.0 if ang_abs < 0.3 else 0.0
+
+        # If near wall & close to ball horizontally, start lift
+        dx = abs(me.physics.location.x - side_x)
+        dist_xy = float(np.hypot(me.physics.location.x - ball.physics.location.x,
+                                 me.physics.location.y - ball.physics.location.y))
+
+        if dx < 450.0 and dist_xy < 800.0:
+            # pop: quick jump if ball is slightly above hood and we are aligned
+            if 60 < (ball.physics.location.z - me.physics.location.z) < 220 and ang_abs < 0.35:
+                ctl.jump = True
+            # chase with soft boost + slight pitch up
+            ctl.boost = 1.0 if ang_abs < 0.25 else 0.0
+            ctl.pitch = -0.15  # nose up slightly to keep ball on car in air
+        return ctl
+
+class BackboardDefenseBrain:
+    """
+    Backboard read & clear:
+      - Predict intercept on own backboard plane.
+      - Route to that point; when close, fast aerial & clear toward corner.
+    """
+    def __init__(self): self.active = False; self.t0 = 0.0
+
+    def act(self, packet, index):
+        me = packet.game_cars[index]; team = me.team; ball = packet.game_ball
+        ctl = SimpleControllerState()
+        P, t = backboard_intercept(ball, team, max_t=2.0)
+        if P is None:
+            # fallback: head to back-post spot
+            bx = -900.0 if ball.physics.location.x < 0 else 900.0
+            by = -5120.0 if team == 0 else 5120.0
+            steer, ang_abs = steer_to(me, (bx, by))
+            ctl.steer = steer; ctl.throttle = 1.0; ctl.boost = 1.0 if ang_abs < 0.25 else 0.0
+            return ctl
+
+        # ground routing
+        steer, ang_abs = steer_to(me, (P[0], P[1]))
+        ctl.steer = steer
+        ctl.throttle = 1.0
+        ctl.boost = 1.0 if ang_abs < 0.3 else 0.0
+
+        # jump/fast aerial if we need height soon
+        dz = P[2] - me.physics.location.z
+        dist_xy = float(np.hypot(P[0] - me.physics.location.x, P[1] - me.physics.location.y))
+        if dz > 200.0 and dist_xy < 1200.0:
+            ctl.jump = True
+            ctl.pitch = -0.8  # pitch up for aerial
+            ctl.boost = 1.0
+
+        # clear toward far corner (diagonal) on contact
+        # renderer-free: bias yaw toward far-corner direction mildly
+        far_corner_x = -3072.0 if P[0] > 0 else 3072.0
+        # y stays same – we want off the backboard toward side
+        # Add mild yaw bias
+        desired = math.atan2(P[1] - me.physics.location.y, far_corner_x - me.physics.location.x)
+        cur = me.physics.rotation.yaw
+        dang = desired - cur
+        while dang > math.pi: dang -= 2*math.pi
+        while dang < -math.pi: dang += 2*math.pi
+        ctl.yaw = _clip(0.3 * dang)
+        return ctl

--- a/decision_head.py
+++ b/decision_head.py
@@ -1,7 +1,7 @@
 # decision_head.py — intent guards that shape/control actions
 import numpy as np
 
-INTENTS = {"PRESS","CONTROL","CHALLENGE","SHADOW","BOOST","CLEAR","DRIBBLE","SHOOT","FAKE","ROTATE_BACK_POST","STARVE","BUMP"}
+INTENTS = {"PRESS","CONTROL","CHALLENGE","SHADOW","BOOST","CLEAR","DRIBBLE","SHOOT","FAKE","ROTATE_BACK_POST","STARVE","BUMP","AIR_DRIBBLE","BACKBOARD_DEFEND"}
 
 def guard_by_intent(intent: str, action: np.ndarray, ctx: dict) -> np.ndarray:
     """
@@ -63,6 +63,20 @@ def guard_by_intent(intent: str, action: np.ndarray, ctx: dict) -> np.ndarray:
         a[1] = min(a[1], 0.2)
         a[6] = 0.0
         a[5] = 0.0
+        return a
+
+    if intent == "AIR_DRIBBLE":
+        # smooth control: moderate throttle, low jump rate (air touch stability), save boost for carry
+        a[1] = float(np.clip(a[1], 0.5, 1.0))
+        a[6] = float(np.clip(a[6], 0.0, 0.8))
+        a[7] = 0.0
+        return a
+
+    if intent == "BACKBOARD_DEFEND":
+        # decisive retreat-to-backboard: full throttle, controlled boost, no handbrake
+        a[1] = 1.0
+        a[6] = max(a[6], 0.6)
+        a[7] = 0.0
         return a
 
     return a

--- a/drills_ssl.py
+++ b/drills_ssl.py
@@ -198,6 +198,44 @@ def inject_half_flip(agent):
         agent.set_game_state(GameState(ball=ball_state, cars={agent.index: car_state}))
 
 
+def inject_wall_airdribble(agent):
+    team = agent.team
+    side = -1 if np.random.rand() < 0.5 else 1
+    ball_x = 2200 * side
+    ball_y = -1500 if team==0 else 1500
+    car_x  = ball_x - 500 * side
+    car_y  = ball_y - (450 * (-1 if team==0 else 1))
+    car_z  = 50
+    ball_z = 200
+    car_state = CarState(physics=Physics(location=Vector3(car_x, car_y, car_z),
+                                         rotation=Rotator(0, 0, 0),
+                                         velocity=Vector3(0,0,0)),
+                         boost_amount=100)
+    ball_state = BallState(physics=Physics(location=Vector3(ball_x, ball_y, ball_z),
+                                           velocity=Vector3(0, 0, 0)))
+    if getattr(agent, "_state_setting_ok", False):
+        agent.set_game_state(GameState(ball=ball_state, cars={agent.index: car_state}))
+
+
+def inject_backboard_defense(agent):
+    team = agent.team
+    # ball toward our backboard
+    ball_x = np.random.uniform(-1200, 1200)
+    ball_y = -4200 if team==0 else 4200
+    ball_z = np.random.uniform(900, 1400)
+    bvy = -700 if team==1 else 700  # moving toward our board
+    car_x  = np.random.uniform(-1200, 1200)
+    car_y  = -2400 if team==0 else 2400
+    car_state = CarState(physics=Physics(location=Vector3(car_x, car_y, 50),
+                                         rotation=Rotator(0, 0, 0),
+                                         velocity=Vector3(0,0,0)),
+                         boost_amount=60)
+    ball_state = BallState(physics=Physics(location=Vector3(ball_x, ball_y, ball_z),
+                                           velocity=Vector3(0, bvy, np.random.uniform(-50, 150))))
+    if getattr(agent, "_state_setting_ok", False):
+        agent.set_game_state(GameState(ball=ball_state, cars={agent.index: car_state}))
+
+
 def inject_wave_dash(agent):
     # Small hop then land — encourage wave dash
     team = agent.team

--- a/mechanics_ssl.py
+++ b/mechanics_ssl.py
@@ -303,6 +303,20 @@ class SkillTelemetry:
         low50 = (under_ball and latest_touch_me and dz < 350 and abs(ball_vel.y) + abs(ball_vel.x) > 500)
         info["low50_success"] = 1.0 if low50 else 0.0
 
+        # Air-dribble control: consecutive airborne self touches at z>600 with speed under control
+        info["air_dribble_ctrl"] = float(min(1.0, info.get("air_dribble_chain", 0.0)))
+
+        # Backboard save: our touch near own backboard at z>900 and ball exits toward corner (x moving outward)
+        own_board = ( (team==0 and ball_loc.y < -4900) or (team==1 and ball_loc.y > 4900) )
+        outward = abs(ball_vel.x) > 400
+        backboard_save = (own_board and latest_touch_me and ball_loc.z > 900 and outward)
+        info["backboard_save"] = 1.0 if backboard_save else 0.0
+
+        # Corner clear quality after save: ball speed toward side + downward
+        sideward = abs(ball_vel.x) > 700
+        downward = ball_vel.z < -150
+        info["corner_clear_quality"] = 1.0 if (backboard_save and sideward and downward) else 0.0
+
         # store for next tick
         self._ball_speed_prev = ball_spd
         self._last_touch_me = latest_touch_me

--- a/rewards_ssl.py
+++ b/rewards_ssl.py
@@ -18,6 +18,9 @@ DEFAULT_SSL_W = {
     "ceiling_shot": 0.30,
     "musty": 0.25,
     "double_tap": 0.35,
+    "air_dribble_ctrl": 0.45,
+    "backboard_save": 0.60,
+    "corner_clear": 0.35,
     # Ultra-efficient reads / movement
     "zap_chain": 0.20,
     "stall": 0.15,
@@ -78,6 +81,11 @@ class SSLReward:
         r += g["ceiling_shot"] * info.get("ceiling_setup", 0.0)
         r += g["musty"] * info.get("musty_attempt", 0.0)
         r += g["double_tap"] * info.get("double_tap_attempt", 0.0)
+
+        # Aerial play mastery
+        r += g["air_dribble_ctrl"] * info.get("air_dribble_ctrl", 0.0)
+        r += g["backboard_save"]   * info.get("backboard_save", 0.0)
+        r += g["corner_clear"]     * info.get("corner_clear_quality", 0.0)
 
         # Ultra-efficient reads
         r += g["zap_chain"] * info.get("zap_chain_dash", 0.0)

--- a/simple_policy.py
+++ b/simple_policy.py
@@ -119,6 +119,15 @@ class HeuristicBrain:
         ):
             jump = 1.0
 
+        # If we were asked to AIR_DRIBBLE, bias toward sidewall carry & gentle pop
+        if intent == "AIR_DRIBBLE":
+            # favor boost only when aligned; encourage small jump when under-ball near wall
+            if abs(me.physics.location.x) > 1800 and 60 < (ball.physics.location.z - me.physics.location.z) < 220 and abs(ang_err) < 0.35:
+                jump = 1.0
+            boost = 1.0 if abs(ang_err) < 0.25 else 0.0
+            # slight nose up
+            pitch = -0.15
+
         # Intent steering aids
         if intent == "BOOST" or intent == "STARVE":
             # steer toward suggested pad target from ctx if present via extras (caller may nudge steer directly)


### PR DESCRIPTION
## Summary
- Introduce AirDribbleBrain and BackboardDefenseBrain for wall carries and backboard saves
- Integrate aerial awareness, intents, drills, telemetry and rewards
- Expand heuristics, decision guards and bot pipeline for aerial play

## Testing
- `python -m py_compile awareness_ssl.py bot.py decision_head.py drills_ssl.py mechanics_ssl.py rewards_ssl.py simple_policy.py aerial_play.py`


------
https://chatgpt.com/codex/tasks/task_e_68b801cd36548323a0e75b15a7b804a3