### PR TITLE
Add exploit finisher and telemetry

### DIFF
--- a/decision_head.py
+++ b/decision_head.py
@@ -1,7 +1,7 @@
 # decision_head.py — intent guards that shape/control actions
 import numpy as np
 
-INTENTS = {"PRESS","CONTROL","CHALLENGE","SHADOW","BOOST","CLEAR","DRIBBLE","SHOOT","FAKE","ROTATE_BACK_POST","STARVE","BUMP","AIR_DRIBBLE","BACKBOARD_DEFEND"}
+INTENTS = {"PRESS","CONTROL","CHALLENGE","SHADOW","BOOST","CLEAR","DRIBBLE","SHOOT","FAKE","ROTATE_BACK_POST","STARVE","BUMP","AIR_DRIBBLE","BACKBOARD_DEFEND","EXPLOIT"}
 
 def guard_by_intent(intent: str, action: np.ndarray, ctx: dict) -> np.ndarray:
     """
@@ -76,6 +76,13 @@ def guard_by_intent(intent: str, action: np.ndarray, ctx: dict) -> np.ndarray:
         # decisive retreat-to-backboard: full throttle, controlled boost, no handbrake
         a[1] = 1.0
         a[6] = max(a[6], 0.6)
+        a[7] = 0.0
+        return a
+
+    if intent == "EXPLOIT":
+        # Aggressive acceleration & boost allowed, keep handbrake off; jumps allowed for finishes
+        a[1] = 1.0
+        a[6] = max(a[6], 0.8)
         a[7] = 0.0
         return a
 

--- a/drills_ssl.py
+++ b/drills_ssl.py
@@ -287,3 +287,31 @@ def inject_net_ramp_pop(agent):
         agent.set_game_state(GameState(cars={agent.index: car_state}))
 
 
+def inject_open_net(agent):
+    team = agent.team
+    # Put ball center-top of box; opponent out of lane
+    ball_x = np.random.uniform(-600, 600)
+    ball_y = 3600 if team==0 else -3600
+    car_y  = ball_y - (900 if team==0 else -900)
+    opp_y  = ball_y + (1600 if team==0 else -1600)
+    opp_x  = 2200 if np.random.rand()<0.5 else -2200
+    car_state_me = CarState(physics=Physics(location=Vector3(0, car_y, 50), rotation=Rotator(0, 0, 0), velocity=Vector3(0,0,0)), boost_amount=60)
+    car_state_opp = CarState(physics=Physics(location=Vector3(opp_x, opp_y, 50), rotation=Rotator(0, 0, 0), velocity=Vector3(0,0,0)), boost_amount=10)
+    ball_state = BallState(physics=Physics(location=Vector3(ball_x, ball_y, 160), velocity=Vector3(0,0,0)))
+    if getattr(agent, "_state_setting_ok", False):
+        agent.set_game_state(GameState(ball=ball_state, cars={agent.index: car_state_me, 1-agent.index: car_state_opp}))
+
+
+def inject_bad_recovery(agent):
+    team = agent.team
+    # Opponent airborne/low boost; ball bouncing in their half
+    ball_x = np.random.uniform(-800, 800)
+    ball_y = 2800 if team==0 else -2800
+    ball_state = BallState(physics=Physics(location=Vector3(ball_x, ball_y, 300), velocity=Vector3(0,0,300)))
+    opp_y  = ball_y + (900 if team==0 else -900)
+    car_state_opp = CarState(physics=Physics(location=Vector3(ball_x+600, opp_y, 500), rotation=Rotator(0,0,0), velocity=Vector3(0,0,0)), boost_amount=0.0)
+    car_state_me = CarState(physics=Physics(location=Vector3(ball_x-800, ball_y-800*(1 if team==0 else -1), 60), rotation=Rotator(0,0,0), velocity=Vector3(0,0,0)), boost_amount=50)
+    if getattr(agent, "_state_setting_ok", False):
+        agent.set_game_state(GameState(ball=ball_state, cars={agent.index: car_state_me, 1-agent.index: car_state_opp}))
+
+

--- a/finisher.py
+++ b/finisher.py
@@ -1,0 +1,89 @@
+# finisher.py — choose and execute a finishing routine when EXPLOITing
+import math, numpy as np
+from rlbot.agents.base_agent import SimpleControllerState
+
+def _clip(x, lo=-1.0, hi=1.0): return float(max(lo, min(hi, x)))
+
+def _aim_steer(me, tx, ty, yaw_gain=2.2, d_gain=0.7):
+    yaw = float(me.physics.rotation.yaw)
+    yaw_rate = float(getattr(me.physics.angular_velocity, "z", 0.0))
+    ang = math.atan2(ty - me.physics.location.y, tx - me.physics.location.x) - yaw
+    while ang > math.pi: ang -= 2*math.pi
+    while ang < -math.pi: ang += 2*math.pi
+    steer = _clip(yaw_gain*ang - d_gain*yaw_rate)
+    return steer, abs(ang)
+
+def _goal_center(team):
+    return (0.0, 5120.0 if team==0 else -5120.0)
+
+class FinisherBrain:
+    """
+    Pick a finish type based on ball height, alignment, ETA edge, and variety:
+      - POWER_SHOT (ground power through lane)
+      - HOOK/45 FLICK (when carrying low)
+      - LOW50 (under-ball vs diving opponent)
+      - BUMP (clean demo line)
+      - AIR_TAP (wall/air carry quick tap)
+      - DOUBLE_TAP (backboard read)
+    Returns a SimpleControllerState.
+    """
+    def __init__(self):
+        self._last_choice = "POWER_SHOT"
+
+    def choose(self, packet, index, ctx):
+        me = packet.game_cars[index]; team = me.team; ball = packet.game_ball
+        bx, by, bz = ball.physics.location.x, ball.physics.location.y, ball.physics.location.z
+        meb = float(getattr(me, "boost", 33.0))
+        eta_me = ctx.get("eta_me_ball", 0.6); eta_opp = ctx.get("eta_opp_ball", 0.8)
+        edge = eta_opp - eta_me
+        # Heuristics
+        if bz < 200 and edge > 0.15:
+            return "POWER_SHOT"
+        if bz < 320 and edge > 0.1 and meb > 20 and ctx.get("possession_idx",0.0) > 0.5:
+            return "HOOK_FLICK"
+        if bz < 250 and edge > 0.05 and ctx.get("possession_idx",0.0) > 0.5:
+            return "LOW50"
+        if bz > 350 and abs(bx) > 1200 and meb > 40 and edge > 0.05:
+            return "AIR_TAP"
+        if bz > 700 and abs(bx) < 1600 and edge > 0.05:
+            return "DOUBLE_TAP"
+        # Rare bump if clean line
+        if edge > 0.10 and meb > 30 and ctx.get("allow_demo", False):
+            return "BUMP"
+        return "POWER_SHOT"
+
+    def act(self, packet, index, ctx):
+        me = packet.game_cars[index]; team = me.team; ball = packet.game_ball
+        choice = self.choose(packet, index, ctx)
+        self._last_choice = choice
+        ctl = SimpleControllerState()
+        gx, gy = _goal_center(team)
+        # Common steering toward a dynamic aim point (slightly inside far post)
+        aim_x = float(np.clip(ball.physics.location.x * 0.7, -800, 800))
+        aim_y = gy * 0.92
+        steer, ang = _aim_steer(me, aim_x, aim_y)
+        ctl.steer = steer; ctl.throttle = 1.0; ctl.boost = 1.0 if ang < 0.35 else 0.0
+
+        bz = ball.physics.location.z
+        # Routines
+        if choice == "POWER_SHOT":
+            # No jump unless close & centered; prefer boost-through
+            if ang < 0.15 and abs(me.physics.location.x - ball.physics.location.x) < 250 and abs(me.physics.location.y - ball.physics.location.y) < 350:
+                ctl.jump = True
+        elif choice == "HOOK_FLICK":
+            # Catch then pop: quick throttle cut, small jump + pitch forward
+            ctl.throttle = 0.6; ctl.boost = 0.0; ctl.jump = True; ctl.pitch = 1.0
+        elif choice == "LOW50":
+            ctl.throttle = 0.8; ctl.boost = 0.2
+            # soft jump to keep ball low on hood
+            ctl.jump = True; ctl.pitch = 0.6
+        elif choice == "AIR_TAP":
+            ctl.jump = True; ctl.pitch = -0.6; ctl.boost = 1.0  # fast aerial pop and tap
+        elif choice == "DOUBLE_TAP":
+            # Aim for high backboard then follow
+            aim_y = gy * 0.98
+            steer, _ = _aim_steer(me, aim_x, aim_y)
+            ctl.steer = steer; ctl.jump = True; ctl.pitch = -0.9; ctl.boost = 1.0
+        elif choice == "BUMP":
+            ctl.boost = 1.0; ctl.throttle = 1.0; ctl.jump = False
+        return ctl, choice

--- a/rewards_ssl.py
+++ b/rewards_ssl.py
@@ -55,6 +55,10 @@ DEFAULT_SSL_W = {
     "low50": 0.30,
     "back_post_cover": 0.25,
     "demo_util": 0.25,
+    "exploit_window": 0.25,
+    "conversion_attempt": 0.35,
+    "conversion_success": 1.50,
+    "finish_variety": 0.10,
 }
 
 
@@ -139,6 +143,12 @@ class SSLReward:
         r += g["low50"]            * info.get("low50_success", 0.0)
         r += g["back_post_cover"]  * info.get("back_post_ok", 0.0)
         r += g["demo_util"]        * info.get("demo_benefit", 0.0)
+
+        # Exploit & conversion
+        r += g["exploit_window"]      * info.get("exploit_window", 0.0)
+        r += g["conversion_attempt"]  * info.get("conversion_attempt", 0.0)
+        r += g["conversion_success"]  * info.get("conversion_success", 0.0)
+        r += g["finish_variety"]      * info.get("finish_variety", 0.0)
 
         return float(max(-1.0, min(1.0, r)))
 


### PR DESCRIPTION
## Summary
- Detect opponent mistakes and mark EXPLOIT windows in awareness
- Add FinisherBrain for aggressive finishes and guard EXPLOIT actions
- Track exploit conversions and finish variety with rewards and drills

## Testing
- `python -m py_compile awareness_ssl.py decision_head.py finisher.py bot.py mechanics_ssl.py rewards_ssl.py drills_ssl.py`

------
https://chatgpt.com/codex/tasks/task_e_68b80be25f508323a08441ea930fb87a