### PR TITLE
Add corner clear danger zone system

### DIFF
--- a/danger_clear.py
+++ b/danger_clear.py
@@ -1,0 +1,57 @@
+# danger_clear.py — when ball is in front of our net, send it safely to a corner
+import math, numpy as np
+from rlbot.agents.base_agent import SimpleControllerState
+
+def _clip(x, lo=-1.0, hi=1.0): return float(max(lo, min(hi, x)))
+
+def steer_to(me, tx, ty, yaw_gain=2.2, d_gain=0.7):
+    yaw = float(me.physics.rotation.yaw)
+    yaw_rate = float(getattr(me.physics.angular_velocity, "z", 0.0))
+    ang = math.atan2(ty - me.physics.location.y, tx - me.physics.location.x) - yaw
+    while ang > math.pi: ang -= 2*math.pi
+    while ang < -math.pi: ang += 2*math.pi
+    steer = _clip(yaw_gain * ang - d_gain * yaw_rate)
+    return steer, abs(ang)
+
+def own_corner_target(team, ball_x, own_goal_y):
+    # pick side corner nearest ball x to minimize center spills
+    cx = 3072.0 if ball_x >= 0 else -3072.0
+    # keep y near our back line but slightly into field to avoid own post pinches
+    cy = own_goal_y + (500.0 if team == 0 else -500.0)
+    return cx, cy
+
+class DangerClearBrain:
+    """
+    Routes car to hit ball toward the safe corner:
+      - Aim at near-side own corner.
+      - Use boost when aligned; jump tap when close & low ball to generate lift.
+      - Never steer aim through center (reduces own-goal risks).
+    """
+    def act(self, packet, index):
+        me = packet.game_cars[index]
+        team = me.team
+        ball = packet.game_ball
+
+        own_goal_y = -5120.0 if team == 0 else 5120.0
+        cx, cy = own_corner_target(team, ball.physics.location.x, own_goal_y)
+
+        ctl = SimpleControllerState()
+        steer, ang = steer_to(me, cx, cy)
+        ctl.steer = steer
+        ctl.throttle = 1.0
+        ctl.boost = 1.0 if ang < 0.35 else 0.0
+
+        # If ball is very low and close, pop it upward slightly to avoid center dribbles
+        dist_xy = float(((me.physics.location.x - ball.physics.location.x)**2 + (me.physics.location.y - ball.physics.location.y)**2) ** 0.5)
+        if ball.physics.location.z < 200.0 and dist_xy < 450.0 and ang < 0.25:
+            ctl.jump = True
+            ctl.pitch = -0.2  # mild upward pop toward corner
+
+        # Mild yaw bias further toward the wall to guarantee side exit
+        desired = math.atan2(cy - me.physics.location.y, cx - me.physics.location.x)
+        cur = float(me.physics.rotation.yaw)
+        dang = desired - cur
+        while dang > math.pi: dang -= 2*math.pi
+        while dang < -math.pi: dang += 2*math.pi
+        ctl.yaw = _clip(0.2 * dang)
+        return ctl

--- a/decision_head.py
+++ b/decision_head.py
@@ -1,7 +1,7 @@
 # decision_head.py — intent guards that shape/control actions
 import numpy as np
 
-INTENTS = {"PRESS","CONTROL","CHALLENGE","SHADOW","BOOST","CLEAR","DRIBBLE","SHOOT","FAKE","ROTATE_BACK_POST","STARVE","BUMP","AIR_DRIBBLE","BACKBOARD_DEFEND","EXPLOIT"}
+INTENTS = {"PRESS","CONTROL","CHALLENGE","SHADOW","BOOST","CLEAR","DRIBBLE","SHOOT","FAKE","ROTATE_BACK_POST","STARVE","BUMP","AIR_DRIBBLE","BACKBOARD_DEFEND","EXPLOIT","CLEAR_CORNER","PANIC_CLEAR"}
 
 def guard_by_intent(intent: str, action: np.ndarray, ctx: dict) -> np.ndarray:
     """
@@ -83,6 +83,21 @@ def guard_by_intent(intent: str, action: np.ndarray, ctx: dict) -> np.ndarray:
         # Aggressive acceleration & boost allowed, keep handbrake off; jumps allowed for finishes
         a[1] = 1.0
         a[6] = max(a[6], 0.8)
+        a[7] = 0.0
+        return a
+
+    if intent == "CLEAR_CORNER":
+        # decisive clear: full throttle, boost allowed, no handbrake spam, allow jump
+        a[1] = 1.0
+        a[6] = max(a[6], 0.7)
+        a[7] = 0.0
+        return a
+
+    if intent == "PANIC_CLEAR":
+        # emergency: more boost, immediate jump tap acceptable
+        a[1] = 1.0
+        a[6] = 1.0
+        a[5] = max(a[5], 0.6)
         a[7] = 0.0
         return a
 

--- a/drills_ssl.py
+++ b/drills_ssl.py
@@ -315,3 +315,41 @@ def inject_bad_recovery(agent):
         agent.set_game_state(GameState(ball=ball_state, cars={agent.index: car_state_me, 1-agent.index: car_state_opp}))
 
 
+def inject_box_clear(agent):
+    team = agent.team
+    own_goal_y = -5120.0 if team == 0 else 5120.0
+    # Ball centered in slot
+    ball_x = np.random.uniform(-600, 600)
+    ball_y = own_goal_y + (1200 if team == 0 else -1200)
+    ball_z = np.random.uniform(120, 240)
+    car_y  = ball_y + ( -900 if team == 0 else 900 )
+    car_x  = np.random.uniform(-900, 900)
+    car_state = CarState(physics=Physics(location=Vector3(car_x, car_y, 60),
+                                         rotation=Rotator(0, 0, 0),
+                                         velocity=Vector3(0,0,0)),
+                         boost_amount=50)
+    ball_state = BallState(physics=Physics(location=Vector3(ball_x, ball_y, ball_z),
+                                           velocity=Vector3(0,0,0)))
+    if getattr(agent, "_state_setting_ok", False):
+        agent.set_game_state(GameState(ball=ball_state, cars={agent.index: car_state}))
+
+
+def inject_box_panic(agent):
+    team = agent.team
+    own_goal_y = -5120.0 if team == 0 else 5120.0
+    ball_x = np.random.uniform(-400, 400)
+    ball_y = own_goal_y + (900 if team == 0 else -900)
+    ball_z = np.random.uniform(100, 300)
+    bvy    = -800 if team == 1 else 800  # moving toward net
+    car_y  = ball_y + ( -600 if team == 0 else 600 )
+    car_x  = np.random.uniform(-600, 600)
+    car_state = CarState(physics=Physics(location=Vector3(car_x, car_y, 60),
+                                         rotation=Rotator(0, 0, 0),
+                                         velocity=Vector3(0,0,0)),
+                         boost_amount=30)
+    ball_state = BallState(physics=Physics(location=Vector3(ball_x, ball_y, ball_z),
+                                           velocity=Vector3(0, bvy, 0)))
+    if getattr(agent, "_state_setting_ok", False):
+        agent.set_game_state(GameState(ball=ball_state, cars={agent.index: car_state}))
+
+

--- a/rewards_ssl.py
+++ b/rewards_ssl.py
@@ -59,6 +59,9 @@ DEFAULT_SSL_W = {
     "conversion_attempt": 0.35,
     "conversion_success": 1.50,
     "finish_variety": 0.10,
+    "own_slot_time_pen": 0.25,
+    "bad_center_touch_pen": 0.80,
+    "corner_clear_success": 0.75,
 }
 
 
@@ -143,6 +146,10 @@ class SSLReward:
         r += g["low50"]            * info.get("low50_success", 0.0)
         r += g["back_post_cover"]  * info.get("back_post_ok", 0.0)
         r += g["demo_util"]        * info.get("demo_benefit", 0.0)
+        # Own-slot safety
+        r -= g["own_slot_time_pen"]    * info.get("own_slot_time", 0.0)
+        r -= g["bad_center_touch_pen"] * info.get("bad_center_touch", 0.0)
+        r += g["corner_clear_success"] * info.get("corner_clear_success", 0.0)
 
         # Exploit & conversion
         r += g["exploit_window"]      * info.get("exploit_window", 0.0)


### PR DESCRIPTION
## Summary
- Detect danger zone in front of own net and bias CLEAR_CORNER intent
- Provide DangerClearBrain with decision guard and override
- Track and reward safe corner clears while penalizing slot spills; add drills and HUD flag

## Testing
- `python -m py_compile awareness_ssl.py decision_head.py danger_clear.py bot.py mechanics_ssl.py rewards_ssl.py drills_ssl.py`

------
https://chatgpt.com/codex/tasks/task_e_68b80deff37483238ef8e7fab0763b58