### PR TITLE
Lock training to Bronze Bootcamp mode

### DIFF
--- a/academy.cfg
+++ b/academy.cfg
@@ -1,0 +1,4 @@
+[Academy]
+show_hud = true
+start_stage = Bronze
+lock_stage = true

--- a/drills_ssl.py
+++ b/drills_ssl.py
@@ -351,5 +351,48 @@ def inject_box_panic(agent):
                                            velocity=Vector3(0, bvy, 0)))
     if getattr(agent, "_state_setting_ok", False):
         agent.set_game_state(GameState(ball=ball_state, cars={agent.index: car_state}))
+def inject_kickoff_basic(agent):
+    # place car & ball for straight/diagonal simple kickoff
+    team = agent.team
+    # Straight spawn
+    car_x, car_y = 0, -2048 if team==0 else 2048
+    ball_state = BallState(physics=Physics(location=Vector3(0,0,92)))
+    car_state = CarState(physics=Physics(location=Vector3(car_x, car_y, 17),
+                                         rotation=Rotator(0, 0, 0),
+                                         velocity=Vector3(0,0,0)),
+                         boost_amount=33)
+    if getattr(agent, "_state_setting_ok", False):
+        agent.set_game_state(GameState(ball=ball_state, cars={agent.index: car_state}))
+
+
+def inject_shadow_lane(agent):
+    # teach staying goal-side & shadowing on same lane
+    team = agent.team
+    y_ball = -2500 if team==0 else 2500
+    y_car  = y_ball - (800 if team==0 else -800)
+    ball_state = BallState(physics=Physics(location=Vector3(0, y_ball, 100), velocity=Vector3(0,0,0)))
+    car_state  = CarState(physics=Physics(location=Vector3(0, y_car, 50), rotation=Rotator(0,0,0)))
+    if getattr(agent,"_state_setting_ok",False):
+        agent.set_game_state(GameState(ball=ball_state, cars={agent.index: car_state}))
+
+
+def inject_corner_push_shot(agent):
+    # ball rolling out of corner -> push to far post
+    team = agent.team
+    side = -1 if np.random.rand()<0.5 else 1
+    bx, by = 2500*side, -3500 if team==0 else 3500
+    ball_state = BallState(physics=Physics(location=Vector3(bx, by, 100), velocity=Vector3(-400*side, 350*(1 if team==0 else -1), 0)))
+    car_state  = CarState(physics=Physics(location=Vector3(bx-700*side, by-600*(1 if team==0 else -1), 50),
+                                         rotation=Rotator(0,0,0), velocity=Vector3(0,0,0)), boost_amount=30)
+    if getattr(agent,"_state_setting_ok",False):
+        agent.set_game_state(GameState(ball=ball_state, cars={agent.index: car_state}))
+
+
+def inject_pad_lane(agent):
+    # place car low boost and a lane of pads ahead
+    team = agent.team
+    car_state = CarState(physics=Physics(location=Vector3(-1000, -2000 if team==0 else 2000, 50)))
+    if getattr(agent,"_state_setting_ok",False):
+        agent.set_game_state(GameState(cars={agent.index: car_state}))
 
 

--- a/rewards_ssl.py
+++ b/rewards_ssl.py
@@ -5,6 +5,7 @@ import numpy as np
 DEFAULT_SSL_W = {
     # Core mastery
     "speedflip": 0.25,
+    "kickoff_first_touch": 0.60,
     "adv_recovery": 0.25,
     "fast_aerial": 0.30,
     "wall_play": 0.20,
@@ -26,9 +27,9 @@ DEFAULT_SSL_W = {
     "stall": 0.15,
     "wavedash_flick": 0.20,
     "deception": 0.20,
-    "perfect_touch": 0.40,
+    "perfect_touch": 0.60,
     # General play
-    "ball_progress": 0.40,
+    "ball_progress": 0.45,
     "touch_quality": 0.30,
     "boost_pos": 0.18,
     "boost_neg": 0.10,
@@ -49,19 +50,21 @@ DEFAULT_SSL_W = {
     "ceiling_reset_w": 0.15,
     "net_ramp_reset_w": 0.10,
     "wall_nose_down_w": 0.15,
-    "small_pads": 0.20,
+    "small_pads": 0.35,
     "boost_delta": 0.15,
     "possession_time": 0.25,
     "low50": 0.30,
-    "back_post_cover": 0.25,
+    "back_post_cover": 0.40,
     "demo_util": 0.25,
     "exploit_window": 0.25,
     "conversion_attempt": 0.35,
     "conversion_success": 1.50,
     "finish_variety": 0.10,
-    "own_slot_time_pen": 0.25,
-    "bad_center_touch_pen": 0.80,
+    "own_slot_time_pen": 0.35,
+    "bad_center_touch_pen": 0.90,
     "corner_clear_success": 0.75,
+    "wasted_boost_pen": 0.25,
+    "reverse_long_pen": 0.20,
 }
 
 
@@ -85,7 +88,7 @@ class SSLReward:
         g = _apply_stage_boosts(self.w, info)
         r = 0.0
         # Core mastery
-        r += g["speedflip"] * info.get("kickoff_first_touch", 0.0)
+        r += g["kickoff_first_touch"] * info.get("kickoff_first_touch", 0.0)
         r += g["adv_recovery"] * info.get("adv_recovery", 0.0)
         r += g["fast_aerial"] * info.get("fast_aerial_attempt", 0.0)
         r += g["wall_play"] * info.get("wall_play", 0.0)
@@ -117,12 +120,13 @@ class SSLReward:
         r += g["ball_progress"] * info.get("ball_to_opp_goal_cos", 0.0)
         r += g["touch_quality"] * info.get("ball_speed_gain_norm", 0.0)
         r += g["boost_pos"] * info.get("boost_use_good", 0.0)
-        r -= g["boost_neg"] * info.get("boost_waste", 0.0)
+        r -= g["wasted_boost_pen"] * info.get("boost_waste", 0.0)
         r -= g["overcommit"] * info.get("last_man_break_flag", 0.0)
         r += g["kickoff"] * info.get("kickoff_score", 0.0)
         r += g["goal"] * info.get("scored", 0.0)
         r -= g["concede"] * info.get("conceded", 0.0)
         r -= g["idle"] * info.get("idle_ticks", 0.0)
+        r -= g["reverse_long_pen"] * info.get("reverse_long", 0.0)
 
         # Awareness taps
         r += g["pressure_awareness"]   * info.get("pressure_idx", 0.0)

--- a/simple_policy.py
+++ b/simple_policy.py
@@ -110,6 +110,13 @@ class HeuristicBrain:
         handbrake = 1.0 if (abs(ang_err) > self.handbrake_thresh and dist < 1500.0) else 0.0
         boost = 1.0 if (abs(ang_err) < self.align_boost_thresh and my_speed < 2200.0) else 0.0
 
+        # Bronze Bootcamp helpers
+        if getattr(self.agent, "_bronze_mode", False):
+            boost = 1.0 if abs(ang_err) < 0.25 else 0.0
+            if bool(getattr(packet.game_info, "is_kickoff_pause", False)) and abs(ang_err) < 0.2 and dist < 450:
+                jump = 1.0
+                pitch = 1.0  # front-flip
+
         # long flip when far & slow & aligned
         if (
             dist > self.flip_dist


### PR DESCRIPTION
## Summary
- Add `academy.cfg` to start and lock Destroyer Academy at Bronze stage with HUD enabled
- Gate advanced intents and graduation; tag HUD and adjust drills for Bronze Bootcamp
- Emphasize Bronze fundamentals with heuristic, reward, and drill updates

## Testing
- `python -m py_compile newmainbot/bot.py newmainbot/drills_ssl.py newmainbot/simple_policy.py newmainbot/rewards_ssl.py`


------
https://chatgpt.com/codex/tasks/task_e_68b8129c8de083239ae15641059a42ae