### PR TITLE
Add optional Torch model with Bronze fallback

### DIFF
--- a/bot.cfg
+++ b/bot.cfg
@@ -1,0 +1,8 @@
+[Locations]
+looks_config = ./appearance.cfg
+python_file = ./bot.py
+requirements_file = ./requirements.txt
+logo_file = ./nexto_logo.png
+name = Destroyer (Bronze)
+maximum_tick_rate_preference = 120
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,10 @@
-rlbot==1.*
-numpy==1.26.4
-rlgym-compat>=1.1    # allow newer compat
+rlbot>=1.33,<2
+numpy>=1.23
+rlgym-compat>=1.1
 
-# Torch is optional; only needed if you want to load a model at runtime.
+# Optional: only needed if you want to load a TorchScript model at runtime.
 --find-links https://download.pytorch.org/whl/torch_stable.html
 torch==2.0.1+cpu
 
 pip
+

--- a/rlbot.cfg
+++ b/rlbot.cfg
@@ -14,10 +14,10 @@ Game Speed = Default
 Boost Amount = Default
 
 [Participant Configuration]
-participant_config_0 = destroyer.cfg
+participant_config_0 = bot.cfg
 participant_team_0 = 0
 participant_type_0 = rlbot
 
-participant_config_1 = destroyer.cfg
+participant_config_1 = bot.cfg
 participant_team_1 = 1
 participant_type_1 = rlbot


### PR DESCRIPTION
## Summary
- make agent model loading optional and add Bronze fallback driver
- update bot and RLBot configs for Destroyer Bronze
- refresh requirements

## Testing
- `python -m py_compile agent.py bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68b8cb4965248323a120820c28e930c0